### PR TITLE
Use dci-cvp role to deploy testpmd operator

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -3,6 +3,35 @@
   set_fact:
     cnf_namespace: "example-cnf"
 
+- name: create namespace
+  k8s:
+    api_version: v1
+    name: "{{ dci_openshift_app_ns }}"
+    kind: Namespace
+
+- name: Execute CVP/OVP Operators role
+  include_role:
+    name: dci-cvp
+  vars:
+    dci_cvp_bundle_spec:  "{{ cvp_bundle_spec }}"
+    dci_cvp_bundle_tag:  "{{ cvp_bundle_tag }}"
+    dci_cvp_pullsecret_file: "{{ tnf_registry_creds }}"
+    dci_cvp_registry_host: "{{ tnf_registry }}"
+    dci_cvp_cache_dir: "{{ dci_cache_dir }}"
+    dci_cvp_cs_url: "{{ dci_cs_url }}"
+    dci_cvp_client_id: "{{ dci_client_id }}"
+    dci_cvp_api_secret: "{{ dci_api_secret }}"
+    dci_cvp_pyxis_submit: "{{ cvp_submit| default(false) }}"
+    dci_cvp_pyxis_apikey: "{{ pyxis_apikey| default(omit) }}"
+    dci_cvp_pyxis_identifier: "{{ pyxis_identifier| default(omit) }}"
+    dci_cvp_kubeconfig: "{{ kubeconfig }}"
+    dci_cvp_namespace: "{{ dci_openshift_app_ns | defaut('!create') }}"
+  when:
+    - cvp_bundle_spec is defined
+    - cvp_bundle_tag is defined
+    - tnf_registry is defined
+    - tnf_registry_creds is defined
+
 - name: Get oc version output
   shell: |
     {{ oc_tool_path }} --kubeconfig {{ kubeconfig_path }} version


### PR DESCRIPTION
This will mirror the bundle image to the local_registry and create an
index that will be used when subscribing to the operator. Following that
all container dependencies will be collected and scorecard tests run.