### PR TITLE
Add mirroring role for example-cnf

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -64,7 +64,7 @@
 
 - name: Mirror rh-nfv images when disconnected
   include_role:
-    name: mirror-rh-nfv
+    name: "{{ dci_config_dir }}/hooks/roles/mirror-rh-nfv"
   vars:
     example_cnf_index_image: quay.io/rh-nfv-int/nfv-example-cnf-catalog:v0.2.6
   when:

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -63,7 +63,8 @@
   become: true
 
 - name: Mirror rh-nfv images when disconnected
-  include_role: mirror-rh-nfv
+  include_role:
+    name: mirror-rh-nfv
   vars:
     example_cnf_index_image: quay.io/rh-nfv-int/nfv-example-cnf-catalog:v0.2.6
   when:

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -62,6 +62,14 @@
     state: latest
   become: true
 
+- name: Mirror rh-nfv images when disconnected
+  include_role: mirror-rh-nfv
+  vars:
+    example_cnf_index_image: quay.io/rh-nfv-int/nfv-example-cnf-catalog:v0.2.6
+  when:
+    - dci_disconnected is defined
+    - dci_disconnected is true
+
 - name: Deploy NFV Example CNF catalog
   include_role:
     name: "{{ dci_config_dir }}/hooks/{{ cluster_name }}/nfv-example-cnf-deploy/roles/example-cnf-catalog"

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -68,7 +68,7 @@
     example_cnf_index_image: quay.io/rh-nfv-int/nfv-example-cnf-catalog:v0.2.6
   when:
     - dci_disconnected is defined
-    - dci_disconnected is true
+    - dci_disconnected|bool
 
 - name: Deploy NFV Example CNF catalog
   include_role:

--- a/testpmd/hooks/roles/mirror-rh-nfv/defaults/main.yml
+++ b/testpmd/hooks/roles/mirror-rh-nfv/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+mrn_index_image: "{{ example_cnf_index_image | default('quay.io/rh-nfv-int/nfv-example-cnf-catalog:v0.2.6') }}"
+mrn_local_registry: "{{ local_registry | default('registry.dfwt5g.lab:5000') }}"
+mrn_mirror_index_image: "{{ mrn_index_image | regex_replace('^[^/]+', mrn_local_registry) }}"
+mrn_pull_secret: "{{ dci_pullsecret_file }}"

--- a/testpmd/hooks/roles/mirror-rh-nfv/defaults/main.yml
+++ b/testpmd/hooks/roles/mirror-rh-nfv/defaults/main.yml
@@ -2,4 +2,4 @@
 mrn_index_image: "{{ example_cnf_index_image | default('quay.io/rh-nfv-int/nfv-example-cnf-catalog:v0.2.6') }}"
 mrn_local_registry: "{{ local_registry | default('registry.dfwt5g.lab:5000') }}"
 mrn_mirror_index_image: "{{ mrn_index_image | regex_replace('^[^/]+', mrn_local_registry) }}"
-mrn_pull_secret: "{{ dci_pullsecret_file }}"
+mrn_pull_secret: "{{ dci_pullsecret_file|default('/opt/cache/pull-secret.txt') }}"

--- a/testpmd/hooks/roles/mirror-rh-nfv/handlers/main.yml
+++ b/testpmd/hooks/roles/mirror-rh-nfv/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: "Delete temporary directories"
+  file:
+    path: "{{ mrn_manifest_dir }}"
+    state: absent

--- a/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
+++ b/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
@@ -46,3 +46,4 @@
   until: '"Working" not in cluster_nodes.resources | json_query("[].metadata.annotations.\"machineconfiguration.openshift.io/state\"")'
   retries: 240
   delay: 10
+  failed_when: '"Degraded" in cluster_nodes.resources | json_query("[].metadata.annotations.\"machineconfiguration.openshift.io/state\"")'

--- a/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
+++ b/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
@@ -25,13 +25,13 @@
     cmd: >
       oc adm catalog mirror
       -a {{ mrn_pull_secret }}
-      --to-manifests={{ mnr_manifest_dir }}
+      --to-manifests={{ mrn_manifest_dir.path }}
       {{ mrn_mirror_index_image }}
       {{ mrn_local_registry }}
 
 - name: "Apply ImageContentSourcePolicy"
   k8s:
-    src: "{{ mrn_manifest_dir }}/imageContentSourcePolicy.yaml"
+    src: "{{ mrn_manifest_dir.path }}/imageContentSourcePolicy.yaml"
   notify: "Delete temporary directories"
 
 - name: "Wait for a moment to machine configs (if any) to render"

--- a/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
+++ b/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+- name: "Mirror index image"
+  shell:
+    cmd: >
+      skopeo copy 
+      --all
+      --authfile {{ mrn_pull_secret }}
+      --dest-tls-verify=false
+      --remove-signatures
+      docker://{{ mrn_index_image }}
+      docker://{{ mrn_mirror_index_image }}
+  register: copy
+  retries: 5
+  delay: 5
+  until:
+    - copy is not failed
+
+- name: "Create temp manifest dir"
+  tempfile:
+    state: directory
+  register: mrn_manifest_dir
+
+- name: "Mirror images from index"
+  shell:
+    cmd: >
+      oc adm catalog mirror
+      -a {{ mrn_pull_secret }}
+      --to-manifests={{ mnr_manifest_dir }}
+      {{ mrn_mirror_index_image }}
+      {{ mrn_local_registry }}
+
+- name: "Apply ImageContentSourcePolicy"
+  k8s:
+    src: "{{ mrn_manifest_dir }}/imageContentSourcePolicy.yaml"
+  notify: "Delete temporary directories"
+
+- name: "Wait for a moment to machine configs (if any) to render"
+  pause:
+    seconds: 30
+
+- name: "Wait for ALL nodes to be in a Done state"
+  k8s_info:
+    api: v1
+    kind: Node
+  register: cluster_nodes
+  until: '"Working" not in cluster_nodes.resources | json_query("[].metadata.annotations.\"machineconfiguration.openshift.io/state\"")'
+  retries: 240
+  delay: 10


### PR DESCRIPTION
- Add a role to mirror example-cnf index and related images when using a disconnected environment

Depends-on: https://github.com/dci-labs/inventories/pull/31