### PR TITLE
Bump version to use 0.2.6 in operators and 0.2.2 apps

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -23,15 +23,15 @@
 
 - name: Create example-cnf facts
   set_fact:
-    operator_version: v0.2.1
-    app_version: v0.2.0
+    operator_version: v0.2.6
+    app_version: v0.2.2
     cnf_app_networks:
       - name: intel-numa0-net1
         count: 2
     packet_generator_networks:
       - name: intel-numa0-net2
         count: 2
-    example_cnf_deploy_script_version: v0.2-1
+    example_cnf_deploy_script_version: master
     run_migration_test: false
     mac_workaround_enable: false
 


### PR DESCRIPTION
- Use `v0.2.6` in operators
- Use `v0.2.2` in apps
- Use `master` (for now) in the nfv-example-cnf-deploy repo