### PR TITLE
Add required package by example-cnf-deploy

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -65,6 +65,7 @@
       - make
       - python3-openshift
       - python3-pyyaml
+      - ansible-collection-community-kubernetes
     state: latest
   become: true
 


### PR DESCRIPTION
- In https://github.com/rh-nfv-int/nfv-example-cnf-deploy/pull/14 example-CNF [introduced the use of `k8s_log`](https://github.com/rh-nfv-int/nfv-example-cnf-deploy/blob/master/roles/example-cnf-app/tasks/retry-trex.yaml#L26) that is **not** available natively in 2.9, but is available through collections
