### PR TITLE
Include task to create cnf_namespace

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -41,6 +41,13 @@
     run_migration_test: false
     mac_workaround_enable: false
 
+- name: "Create CNF Namespace"
+  k8s:
+    api_version: v1
+    kind: Namespace
+    state: present
+    name: "{{ cnf_namespace }}"
+
 - name: Set mac workround for ocp older than 4.6
   set_fact:
     mac_workaround_enable: true


### PR DESCRIPTION
Before the namespace was created during the SR-IOV operator
setup, but we believe this is a better place for that task.
This is related to: https://softwarefactory-project.io/r/c/dci-openshift-agent/+/22717