### PR TITLE
Upgrading example-cnf to execute CNF Cert Suite v3.0.0

### DIFF
--- a/testpmd/hooks/install.yml
+++ b/testpmd/hooks/install.yml
@@ -5,7 +5,7 @@
 
 - name: Apply configuration for CNF Cert Suite execution
   include_role:
-    name: apply-cnf-cert-config
+    name: "{{ dci_config_dir }}/hooks/roles/apply-cnf-cert-config"
   when: do_cnf_cert|default(false)|bool
 
 ...

--- a/testpmd/hooks/install.yml
+++ b/testpmd/hooks/install.yml
@@ -6,6 +6,7 @@
 - name: Apply configuration for CNF Cert Suite execution
   include_role:
     name: "{{ dci_config_dir }}/hooks/roles/apply-cnf-cert-config"
+    tasks_from: install.yml
   when: do_cnf_cert|default(false)|bool
 
 ...

--- a/testpmd/hooks/install.yml
+++ b/testpmd/hooks/install.yml
@@ -3,4 +3,9 @@
   include_role:
     name: "{{ dci_config_dir }}/hooks/{{ cluster_name }}/nfv-example-cnf-deploy/roles/example-cnf-app"
 
+- name: Apply configuration for CNF Cert Suite execution
+  include_role:
+    name: apply-cnf-cert-config
+  when: do_cnf_cert|default(false)|bool
+
 ...

--- a/testpmd/hooks/post-run.yml
+++ b/testpmd/hooks/post-run.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Clean configuration for CNF Cert Suite execution
+  include_role:
+    name: "{{ dci_config_dir }}/hooks/roles/apply-cnf-cert-config"
+    tasks_from: post-run.yml
+  when: do_cnf_cert|default(false)|bool
+
+...

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -37,7 +37,6 @@
     packet_generator_networks:
       - name: intel-numa0-net2
         count: 2
-    example_cnf_deploy_script_version: master
     run_migration_test: false
     mac_workaround_enable: false
 

--- a/testpmd/hooks/roles/apply-cnf-cert-config/defaults/main.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 app_ns: "{{ dci_openshift_app_ns|default('example-cnf') }}"
 operators_regexp: "{{ tnf_operators_regexp|default('cnf-app-mac|testpmd-operator') }}"
-cnfs_regexp: "{{ tnf_cnfs_regexp|default('testpmd-operator|testpmd-app') }}"
 exclude_connectivity_regexp: "{{ tnf_exclude_connectivity_regexp|default('.*') }}"
 targetpodlabels_name: "{{ tnf_targetpodlabels_name|default('tnf') }}"
 targetpodlabels_value: "{{ tnf_targetpodlabels_value|default('target') }}"

--- a/testpmd/hooks/roles/apply-cnf-cert-config/defaults/main.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+app_ns: "{{ dci_openshift_app_ns|default('example-cnf') }}"
+operators_regexp: "{{ tnf_operators_regexp|default('cnf-app-mac|testpmd-operator') }}"
+cnfs_regexp: "{{ tnf_cnfs_regexp|default('testpmd-operator|testpmd-app') }}"
+exclude_connectivity_regexp: "{{ tnf_exclude_connectivity_regexp|default('.*') }}"
+targetpodlabels_name: "{{ tnf_targetpodlabels_name|default('tnf') }}"
+targetpodlabels_value: "{{ tnf_targetpodlabels_value|default('target') }}"
+
+...

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/install.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/install.yml
@@ -1,6 +1,8 @@
 ---
 
-# Label/Annotate pods - WIP
+# Label pods - only the labels related to exclude connectivity features, as the
+# pods are autodiscovered based on the labels provided in tnf_targetpodlabels variable
+# in the pipeline
 
 - name: Get pods from example-cnf namespace
   k8s_info:
@@ -9,17 +11,10 @@
     namespace: "{{ app_ns }}"
   register: example_cnf_pod_list
 
-# In this case and the following, labels are included after deploying the pods. However, as stated here:
+# Labels are included after deploying the pods. However, as stated here:
 # https://github.com/test-network-function/test-network-function#targetpodlabels
-# "It's highly recommended that the labels should be defined in pod definition rather than added after pod is created"
-- name: Tag pods with autodiscovery labels/annotations to execute test suites
-  shell: |
-    set -ex
-    oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" "{{ app_ns }}"/"{{ targetpodlabels_name }}"="{{ targetpodlabels_value }}" --overwrite
-    oc annotate pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/container_tests="[\"PRIVILEGED_POD\",\"PRIVILEGED_ROLE\"]" --overwrite
-  when: item.metadata.name|regex_search(cnfs_regexp)
-  loop: "{{ example_cnf_pod_list.resources }}"
-
+# "It's highly recommended that the labels should be defined in pod definition rather 
+# than added after pod is created"
 - name: Tag pods with autodiscovery labels related to exclude connectivity features in test suites
   shell: |
     set -ex

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/install.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/install.yml
@@ -1,0 +1,56 @@
+---
+
+# Label/Annotate pods - WIP
+
+- name: Get pods from example-cnf namespace
+  k8s_info:
+    api_version: v1
+    kind: pod
+    namespace: "{{ app_ns }}"
+  register: example_cnf_pod_list
+
+# In this case and the following, labels are included after deploying the pods. However, as stated here:
+# https://github.com/test-network-function/test-network-function#targetpodlabels
+# "It's highly recommended that the labels should be defined in pod definition rather than added after pod is created"
+- name: Tag pods with autodiscovery labels/annotations to execute test suites
+  shell: |
+    set -ex
+    oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" "{{ app_ns }}"/"{{ targetpodlabels_name }}"="{{ targetpodlabels_value }}" --overwrite
+    oc annotate pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/container_tests="[\"PRIVILEGED_POD\",\"PRIVILEGED_ROLE\"]" --overwrite
+  when: item.metadata.name|regex_search(cnfs_regexp)
+  loop: "{{ example_cnf_pod_list.resources }}"
+
+- name: Tag pods with autodiscovery labels related to exclude connectivity features in test suites
+  shell: |
+    set -ex
+    oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/skip_connectivity_tests=true --overwrite
+  when:  item.metadata.name|regex_search(exclude_connectivity_regexp)
+  loop: "{{ example_cnf_pod_list.resources }}"
+
+# Label/Annotate operators
+
+- name: Get CSVs from example-cnf namespace
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    namespace: "{{ app_ns }}"
+  register: example_cnf_csv_list
+
+# Subscription names are retrieved from the install plan that corresponds to the CSV.
+- name: Tag CSVs with autodiscovery labels/annotations to execute test suites
+  shell: |
+    set -ex
+    
+    oc label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator=target --overwrite
+    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests='["OPERATOR_STATUS"]' --overwrite
+    
+    INSTALL_PLAN_NAME=$(oc get installplan -n "{{ app_ns }}" | grep "{{ item.metadata.name }}" | awk '{ print $1 }')
+    SUBSCRIPTION_NAMES=($(oc get installplan $INSTALL_PLAN_NAME -n "{{ app_ns }}" -o json | jq -r ".metadata.ownerReferences[].name"))
+    SUBSCRIPTION_NAMES_JSON=$(echo ${SUBSCRIPTION_NAMES[@]} | jq -R 'split (" ")')
+
+    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name="$SUBSCRIPTION_NAMES_JSON" --overwrite
+
+  when: item.metadata.name|regex_search(operators_regexp)
+  loop: "{{ example_cnf_csv_list.resources }}"
+
+...

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
@@ -15,17 +15,17 @@
 - name: Tag pods with autodiscover labels to execute test suites
   shell: |
     set -ex
-    oc label pod -n "{{ app_ns }}" "{{ item.resources.pod.metadata.name }}" "{{ app_ns }}"/"{{ targetpodlabels_name }}"="{{ targetpodlabels_value }}" --overwrite
-    oc annotate pod -n "{{ app_ns }}" "{{ item.resources.pod.metadata.name }}" test-network-function.com/container_tests="[\"PRIVILEGED_POD\",\"PRIVILEGED_ROLE\"]" --overwrite
-  when: item.resources.pod.metadata.name|regex_search(cnfs_regexp)
-  loop: "{{ example_cnf_pod_list }}"
+    oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" "{{ app_ns }}"/"{{ targetpodlabels_name }}"="{{ targetpodlabels_value }}" --overwrite
+    oc annotate pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/container_tests="[\"PRIVILEGED_POD\",\"PRIVILEGED_ROLE\"]" --overwrite
+  when: item.metadata.name|regex_search(cnfs_regexp)
+  loop: "{{ example_cnf_pod_list.resources }}"
 
 - name: Tag pods with autodiscover labels related to exclude connectivity features in test suites
   shell: |
     set -ex
-    oc label pod -n "{{ app_ns }}" "{{ item.resources.pod.metadata.name }}" test-network-function.com/skip_connectivity_tests=true --overwrite
-  when:  item.resources.pod.metadata.name|regex_search(exclude_connectivity_regexp)
-  loop: "{{ example_cnf_pod_list }}"
+    oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/skip_connectivity_tests=true --overwrite
+  when:  item.metadata.name|regex_search(exclude_connectivity_regexp)
+  loop: "{{ example_cnf_pod_list.resources }}"
 
 # Label operators / TODO
 

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
@@ -48,7 +48,7 @@
     SUBSCRIPTION_NAMES=($(oc get installplan $INSTALL_PLAN_NAME -n "{{ app_ns }}" -o json | jq -r ".metadata.ownerReferences[].name"))
     SUBSCRIPTION_NAMES_JSON=$(echo ${SUBSCRIPTION_NAMES[@]} | jq -R 'split (" ")')
 
-    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name=\"$SUBSCRIPTION_NAMES_JSON\" --overwrite
+    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name="$SUBSCRIPTION_NAMES_JSON" --overwrite
 
   when: item.metadata.name|regex_search(operators_regexp)
   loop: "{{ example_cnf_csv_list.resources }}"

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
@@ -12,7 +12,7 @@
 # In this case and the following, labels are included after deploying the pods. However, as stated here:
 # https://github.com/test-network-function/test-network-function#targetpodlabels
 # "It's highly recommended that the labels should be defined in pod definition rather than added after pod is created"
-- name: Tag pods with autodiscover labels to execute test suites
+- name: Tag pods with autodiscovery labels to execute test suites
   shell: |
     set -ex
     oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" "{{ app_ns }}"/"{{ targetpodlabels_name }}"="{{ targetpodlabels_value }}" --overwrite
@@ -20,13 +20,29 @@
   when: item.metadata.name|regex_search(cnfs_regexp)
   loop: "{{ example_cnf_pod_list.resources }}"
 
-- name: Tag pods with autodiscover labels related to exclude connectivity features in test suites
+- name: Tag pods with autodiscovery labels related to exclude connectivity features in test suites
   shell: |
     set -ex
     oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/skip_connectivity_tests=true --overwrite
   when:  item.metadata.name|regex_search(exclude_connectivity_regexp)
   loop: "{{ example_cnf_pod_list.resources }}"
 
-# Label operators / TODO
+# Label operators / WIP
+
+- name: Get CSVs from example-cnf namespace
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    namespace: "{{ app_ns }}"
+  register: example_cnf_csv_list
+
+- name: Tag CSVs with autodiscovery labels to execute test suites
+  shell: |
+    set -ex
+    oc label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator=target --overwrite
+    oc label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name=etcd --overwrite
+    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests='["OPERATOR_STATUS"]' --overwrite
+  when: item.metadata.name|regex_search(operators_regexp)
+  loop: "{{ example_cnf_csv_list.resources }}"
 
 ...

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
@@ -27,7 +27,7 @@
   when:  item.metadata.name|regex_search(exclude_connectivity_regexp)
   loop: "{{ example_cnf_pod_list.resources }}"
 
-# Label operators / WIP
+# Label operators
 
 - name: Get CSVs from example-cnf namespace
   k8s_info:
@@ -36,11 +36,12 @@
     namespace: "{{ app_ns }}"
   register: example_cnf_csv_list
 
+# TODO: include correct subscription name
 - name: Tag CSVs with autodiscovery labels to execute test suites
   shell: |
     set -ex
     oc label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator=target --overwrite
-    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name=etcd --overwrite
+    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name='["etcd"]' --overwrite
     oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests='["OPERATOR_STATUS"]' --overwrite
   when: item.metadata.name|regex_search(operators_regexp)
   loop: "{{ example_cnf_csv_list.resources }}"

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
@@ -1,56 +1,11 @@
 ---
+- block:
 
-# Label pods / WIP
+    - name: install
+      include_tasks: install.yml
 
-- name: Get pods from example-cnf namespace
-  k8s_info:
-    api_version: v1
-    kind: pod
-    namespace: "{{ app_ns }}"
-  register: example_cnf_pod_list
+    - name: post-run
+      include_tasks: post-run.yml
 
-# In this case and the following, labels are included after deploying the pods. However, as stated here:
-# https://github.com/test-network-function/test-network-function#targetpodlabels
-# "It's highly recommended that the labels should be defined in pod definition rather than added after pod is created"
-- name: Tag pods with autodiscovery labels to execute test suites
-  shell: |
-    set -ex
-    oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" "{{ app_ns }}"/"{{ targetpodlabels_name }}"="{{ targetpodlabels_value }}" --overwrite
-    oc annotate pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/container_tests="[\"PRIVILEGED_POD\",\"PRIVILEGED_ROLE\"]" --overwrite
-  when: item.metadata.name|regex_search(cnfs_regexp)
-  loop: "{{ example_cnf_pod_list.resources }}"
-
-- name: Tag pods with autodiscovery labels related to exclude connectivity features in test suites
-  shell: |
-    set -ex
-    oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/skip_connectivity_tests=true --overwrite
-  when:  item.metadata.name|regex_search(exclude_connectivity_regexp)
-  loop: "{{ example_cnf_pod_list.resources }}"
-
-# Label operators
-
-- name: Get CSVs from example-cnf namespace
-  k8s_info:
-    api_version: operators.coreos.com/v1alpha1
-    kind: ClusterServiceVersion
-    namespace: "{{ app_ns }}"
-  register: example_cnf_csv_list
-
-# Subscription names are retrieved from the install plan that corresponds to the CSV.
-- name: Tag CSVs with autodiscovery labels to execute test suites
-  shell: |
-    set -ex
-    
-    oc label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator=target --overwrite
-    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests='["OPERATOR_STATUS"]' --overwrite
-    
-    INSTALL_PLAN_NAME=$(oc get installplan -n "{{ app_ns }}" | grep "{{ item.metadata.name }}" | awk '{ print $1 }')
-    SUBSCRIPTION_NAMES=($(oc get installplan $INSTALL_PLAN_NAME -n "{{ app_ns }}" -o json | jq -r ".metadata.ownerReferences[].name"))
-    SUBSCRIPTION_NAMES_JSON=$(echo ${SUBSCRIPTION_NAMES[@]} | jq -R 'split (" ")')
-
-    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name="$SUBSCRIPTION_NAMES_JSON" --overwrite
-
-  when: item.metadata.name|regex_search(operators_regexp)
-  loop: "{{ example_cnf_csv_list.resources }}"
-
+  when: do_cnf_cert|default(false)|bool
 ...

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+
+# Label pods / WIP
+
+- name: Get pods from example-cnf namespace
+  k8s_info:
+    api_version: v1
+    kind: pod
+    namespace: "{{ app_ns }}"
+  register: example_cnf_pod_list
+
+# In this case and the following, labels are included after deploying the pods. However, as stated here:
+# https://github.com/test-network-function/test-network-function#targetpodlabels
+# "It's highly recommended that the labels should be defined in pod definition rather than added after pod is created"
+- name: Tag pods with autodiscover labels to execute test suites
+  shell: |
+    set -ex
+    oc label pod -n "{{ app_ns }}" "{{ item.resources.pod.metadata.name }}" "{{ app_ns }}"/"{{ targetpodlabels_name }}"="{{ targetpodlabels_value }}" --overwrite
+    oc annotate pod -n "{{ app_ns }}" "{{ item.resources.pod.metadata.name }}" test-network-function.com/container_tests="[\"PRIVILEGED_POD\",\"PRIVILEGED_ROLE\"]" --overwrite
+  when: item.resources.pod.metadata.name|regex_search(cnfs_regexp)
+  loop: "{{ example_cnf_pod_list }}"
+
+- name: Tag pods with autodiscover labels related to exclude connectivity features in test suites
+  shell: |
+    set -ex
+    oc label pod -n "{{ app_ns }}" "{{ item.resources.pod.metadata.name }}" test-network-function.com/skip_connectivity_tests=true --overwrite
+  when:  item.resources.pod.metadata.name|regex_search(exclude_connectivity_regexp)
+  loop: "{{ example_cnf_pod_list }}"
+
+# Label operators / TODO
+
+  ...
+  

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
@@ -36,13 +36,20 @@
     namespace: "{{ app_ns }}"
   register: example_cnf_csv_list
 
-# TODO: include correct subscription name
+# Subscription names are retrieved from the install plan that corresponds to the CSV.
 - name: Tag CSVs with autodiscovery labels to execute test suites
   shell: |
     set -ex
+    
     oc label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator=target --overwrite
-    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name='["etcd"]' --overwrite
     oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests='["OPERATOR_STATUS"]' --overwrite
+    
+    INSTALL_PLAN_NAME=$(oc get installplan -n "{{ app_ns }}" | grep "{{ item.metadata.name }}" | awk '{ print $1 }')
+    SUBSCRIPTION_NAMES=($(oc get installplan $INSTALL_PLAN -n "{{ app_ns }}" -o json | jq -r ".metadata.ownerReferences[].name"))
+    SUBSCRIPTION_NAMES_JSON=$(echo ${SUBSCRIPTION_NAMES[@]} | jq -R 'split (" ")')
+
+    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name=\"$SUBSCRIPTION_NAMES_JSON\" --overwrite
+
   when: item.metadata.name|regex_search(operators_regexp)
   loop: "{{ example_cnf_csv_list.resources }}"
 

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
@@ -29,5 +29,4 @@
 
 # Label operators / TODO
 
-  ...
-  
+...

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
@@ -40,7 +40,7 @@
   shell: |
     set -ex
     oc label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator=target --overwrite
-    oc label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name=etcd --overwrite
+    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name=etcd --overwrite
     oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests='["OPERATOR_STATUS"]' --overwrite
   when: item.metadata.name|regex_search(operators_regexp)
   loop: "{{ example_cnf_csv_list.resources }}"

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
@@ -45,7 +45,7 @@
     oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests='["OPERATOR_STATUS"]' --overwrite
     
     INSTALL_PLAN_NAME=$(oc get installplan -n "{{ app_ns }}" | grep "{{ item.metadata.name }}" | awk '{ print $1 }')
-    SUBSCRIPTION_NAMES=($(oc get installplan $INSTALL_PLAN -n "{{ app_ns }}" -o json | jq -r ".metadata.ownerReferences[].name"))
+    SUBSCRIPTION_NAMES=($(oc get installplan $INSTALL_PLAN_NAME -n "{{ app_ns }}" -o json | jq -r ".metadata.ownerReferences[].name"))
     SUBSCRIPTION_NAMES_JSON=$(echo ${SUBSCRIPTION_NAMES[@]} | jq -R 'split (" ")')
 
     oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name=\"$SUBSCRIPTION_NAMES_JSON\" --overwrite

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/post-run.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/post-run.yml
@@ -1,19 +1,8 @@
 ---
 
-# Remove labels/annotations from pods - WIP
+# Remove labels from pods - only the labels related to exclude connectivity features
 
-# In this case and the following, labels are included after deploying the pods. However, as stated here:
-# https://github.com/test-network-function/test-network-function#targetpodlabels
-# "It's highly recommended that the labels should be defined in pod definition rather than added after pod is created"
-- name: Remove autodiscovery labels/annotations from pods
-  shell: |
-    set -ex
-    oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" "{{ app_ns }}"/"{{ targetpodlabels_name }}"-
-    oc annotate pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/container_tests-
-  when: item.metadata.name|regex_search(cnfs_regexp)
-  loop: "{{ example_cnf_pod_list.resources }}"
-
-- name: Remove autodiscovery labels/annotations related to exclude connectivity features from pods
+- name: Remove autodiscovery labels related to exclude connectivity features from pods
   shell: |
     set -ex
     oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/skip_connectivity_tests-

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/post-run.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/post-run.yml
@@ -1,0 +1,35 @@
+---
+
+# Remove labels/annotations from pods - WIP
+
+# In this case and the following, labels are included after deploying the pods. However, as stated here:
+# https://github.com/test-network-function/test-network-function#targetpodlabels
+# "It's highly recommended that the labels should be defined in pod definition rather than added after pod is created"
+- name: Remove autodiscovery labels/annotations from pods
+  shell: |
+    set -ex
+    oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" "{{ app_ns }}"/"{{ targetpodlabels_name }}"-
+    oc annotate pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/container_tests-
+  when: item.metadata.name|regex_search(cnfs_regexp)
+  loop: "{{ example_cnf_pod_list.resources }}"
+
+- name: Remove autodiscovery labels/annotations related to exclude connectivity features from pods
+  shell: |
+    set -ex
+    oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/skip_connectivity_tests-
+  when:  item.metadata.name|regex_search(exclude_connectivity_regexp)
+  loop: "{{ example_cnf_pod_list.resources }}"
+
+# Remove labels/annotations from operators
+
+- name: Remove autodiscovery labels/annotations from CSVs
+  shell: |
+    set -ex
+    
+    oc label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator-
+    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests-
+    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name-
+  when: item.metadata.name|regex_search(operators_regexp)
+  loop: "{{ example_cnf_csv_list.resources }}"
+
+...


### PR DESCRIPTION
Code to enable the usage of CNF Cert Suite v3.0.x on example-cnf, installing the autodiscovery labels required by the suite. Main contribution:

- Creation of autodiscovery labels and annotations in pods (WIP) and operators (working now). Doing it in the install phase.
- Deletion of the autodiscovery labels and annotations after executing the tnf tests, in the post-run phase.