### PR TITLE
Add tasks to create SR-IOV policies and networks

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -48,6 +48,44 @@
     state: present
     name: "{{ cnf_namespace }}"
 
+# Expecting variables in an array on this form
+# sriov_network:
+#  - name: intel-numa0-net1
+#    vlan: 460
+#    policy: intel-numa0-policy1
+#    resource: intel_numa0_res1
+#    numvfs: 16
+#    mtu: 9000
+#    device_type: vfio-pci
+#    devices:
+#      - ens2f1#0-15
+# or
+#  - policy: intel-dpdk-node-policy
+#    resource: intelnics
+#    numvfs: 4
+#    vendor: 8086
+#    deviceid: 1592
+#    devices:
+#      - ens4f0
+#    rootdevices:
+#      - "0000:d8:00.0"
+#    nodeselector: '"node.openshift.io/nic_type": "intel810"'
+- name: "Create SriovNetworkNodePolicy for {{ sriov['policy'] }}"
+  k8s:
+    definition: "{{ lookup('template', 'templates/sriov-policy.yml.j2') }}"
+  loop: "{{ sriov_network }}"
+  loop_control:
+    loop_var: sriov
+  when: sriov_network is defined
+
+- name: "Create SriovNetwork for {{ sriov['name'] }}"
+  k8s:
+    definition: "{{ lookup('template', 'templates/sriov-network.yml.j2') }}"
+  loop: "{{ sriov_network }}"
+  loop_control:
+    loop_var: sriov
+  when: sriov_network is defined
+
 - name: Set mac workround for ocp older than 4.6
   set_fact:
     mac_workaround_enable: true

--- a/testpmd/hooks/templates/sriov-network.yml.j2
+++ b/testpmd/hooks/templates/sriov-network.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: "{{ sriov['name'] }}"
+  namespace: openshift-sriov-network-operator
+spec:
+  networkNamespace: "{{ cnf_namespace }}"
+  vlan: {{ sriov['vlan']|int }}
+  resourceName: "{{ sriov['resource'] }}"
+  spoofChk: "on"
+  trust: "on"
+  ipam: '{ }'

--- a/testpmd/hooks/templates/sriov-policy.yml.j2
+++ b/testpmd/hooks/templates/sriov-policy.yml.j2
@@ -1,0 +1,33 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: {{ sriov['policy'] }}
+  namespace: openshift-sriov-network-operator
+spec:
+  nodeSelector:
+    {{ sriov['nodeselector'] | default('"node-role.kubernetes.io/worker": ""') }}
+  resourceName: {{ sriov['resource'] }}
+  priority: {{ sriov['priority'] | default(99) }}
+{% if sriov['mtu'] is defined %}
+  mtu: {{ sriov['mtu'] }}
+{% endif %}
+  numVfs: {{ sriov['numvfs'] }}
+  nicSelector:
+{% if sriov['vendor'] is defined %}
+    vendor: {{ sriov['vendor'] }}
+{% endif %}
+{% if sriov['deviceid'] is defined %}
+    deviceID: {{ sriov['deviceid'] }}
+{% endif %}
+{% if sriov['rootdevices'] is defined %}
+    rootDevices:
+{% for rootdevice in sriov['rootdevices'] %}
+      - {{ rootdevice }}
+{% endfor %}
+{% endif %}
+    pfNames:
+{% for device in sriov['devices'] %}
+      - {{ device }}
+{% endfor %}
+  deviceType: {{ sriov['device_type'] | default('netdevice') }}
+  isRdma: {{ sriov['isrdma']|default(false)|bool }}


### PR DESCRIPTION
These tasks were executed before by the operator-sriov
role in d-o-a, they were moved here as they are required
by this app config.
This is related to https://softwarefactory-project.io/r/c/dci-openshift-agent/+/22743