### PR TITLE
Minor changes, removing unusued variables that were maintained in PR35

### DIFF
--- a/testpmd/hooks/roles/apply-cnf-cert-config/defaults/main.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/defaults/main.yml
@@ -1,8 +1,6 @@
 ---
 app_ns: "{{ dci_openshift_app_ns|default('example-cnf') }}"
-operators_regexp: "{{ tnf_operators_regexp|default('cnf-app-mac|testpmd-operator') }}"
-exclude_connectivity_regexp: "{{ tnf_exclude_connectivity_regexp|default('.*') }}"
-targetpodlabels_name: "{{ tnf_targetpodlabels_name|default('tnf') }}"
-targetpodlabels_value: "{{ tnf_targetpodlabels_value|default('target') }}"
+operators_regexp: "{{ tnf_operators_regexp|default('cnf-app-mac|testpmd-lb-operator|testpmd-operator|trex-operator') }}"
+exclude_connectivity_regexp: "{{ tnf_exclude_connectivity_regexp|default('loadbalancer|testpmd-app') }}"
 
 ...

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/install.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/install.yml
@@ -1,6 +1,6 @@
 ---
 
-# Label pods - only the labels related to exclude connectivity features, as the
+# Label pods - only the labels related to exclude connectivity features are applied, as the
 # pods are autodiscovered based on the labels provided in tnf_targetpodlabels variable
 # in the pipeline
 


### PR DESCRIPTION
I just forgot to remove some unused variables and to change the default values of other variables to be the same than the ones included in the pipeline and I am doing this here. This is not breaking anything, so I will directly merge it.