### PR TITLE
Fixing error when labelling operators

### DIFF
--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/install.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/install.yml
@@ -45,9 +45,9 @@
     if [ $INSTALL_PLAN_NUMBER -ne 0 ]; then
       SUBSCRIPTION_NAMES=()
       for INSTALL_PLAN_NAME in "${INSTALL_PLAN_NAMES[@]}"; do
-        SUBSCRIPTION_NAMES=(${SUBSCRIPTION_NAMES[@]} $(oc get installplan "${INSTALL_PLAN_NAME}" -n "{{ app_ns }}" -o json | jq -r ".metadata.ownerReferences[].name"))
+        SUBSCRIPTION_NAMES+=( $(oc get installplan "${INSTALL_PLAN_NAME}" -n "{{ app_ns }}" -o json | jq -r ".metadata.ownerReferences[].name") )
       done
-      SUBSCRIPTION_NAMES_JSON=$(echo ${SUBSCRIPTION_NAMES[@]} | jq -R 'split (" ")' | jq "unique")
+      SUBSCRIPTION_NAMES_JSON=$(echo ${SUBSCRIPTION_NAMES[@]} | jq -R 'split (" ")| unique')
       oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name="$SUBSCRIPTION_NAMES_JSON" --overwrite
     fi
   when: item.metadata.name|regex_search(operators_regexp)

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/install.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/install.yml
@@ -40,15 +40,13 @@
     oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests='["OPERATOR_STATUS"]' --overwrite
     
     INSTALL_PLAN_NAMES=($(oc get installplan -n "{{ app_ns }}" | grep "{{ item.metadata.name }}" | awk '{ print $1 }'))
-    
-    if [ ${#INSTALL_PLAN_NAMES[@]} -ne 0 ]; then
+    INSTALL_PLAN_NUMBER=$(echo -n ${INSTALL_PLAN_NAMES[@]} | wc -w)
 
+    if [ $INSTALL_PLAN_NUMBER -ne 0 ]; then
       SUBSCRIPTION_NAMES=()
-
       for INSTALL_PLAN_NAME in "${INSTALL_PLAN_NAMES[@]}"; do
         SUBSCRIPTION_NAMES=(${SUBSCRIPTION_NAMES[@]} $(oc get installplan "${INSTALL_PLAN_NAME}" -n "{{ app_ns }}" -o json | jq -r ".metadata.ownerReferences[].name"))
       done
-
       SUBSCRIPTION_NAMES_JSON=$(echo ${SUBSCRIPTION_NAMES[@]} | jq -R 'split (" ")' | jq "unique")
       oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name="$SUBSCRIPTION_NAMES_JSON" --overwrite
     fi

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/install.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/install.yml
@@ -39,12 +39,19 @@
     oc label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator=target --overwrite
     oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests='["OPERATOR_STATUS"]' --overwrite
     
-    INSTALL_PLAN_NAME=$(oc get installplan -n "{{ app_ns }}" | grep "{{ item.metadata.name }}" | awk '{ print $1 }')
-    SUBSCRIPTION_NAMES=($(oc get installplan $INSTALL_PLAN_NAME -n "{{ app_ns }}" -o json | jq -r ".metadata.ownerReferences[].name"))
-    SUBSCRIPTION_NAMES_JSON=$(echo ${SUBSCRIPTION_NAMES[@]} | jq -R 'split (" ")')
+    INSTALL_PLAN_NAMES=($(oc get installplan -n "{{ app_ns }}" | grep "{{ item.metadata.name }}" | awk '{ print $1 }'))
+    
+    if [ ${#INSTALL_PLAN_NAMES[@]} -ne 0 ]; then
 
-    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name="$SUBSCRIPTION_NAMES_JSON" --overwrite
+      SUBSCRIPTION_NAMES=()
 
+      for INSTALL_PLAN_NAME in "${INSTALL_PLAN_NAMES[@]}"; do
+        SUBSCRIPTION_NAMES=(${SUBSCRIPTION_NAMES[@]} $(oc get installplan "${INSTALL_PLAN_NAME}" -n "{{ app_ns }}" -o json | jq -r ".metadata.ownerReferences[].name"))
+      done
+
+      SUBSCRIPTION_NAMES_JSON=$(echo ${SUBSCRIPTION_NAMES[@]} | jq -R 'split (" ")' | jq "unique")
+      oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name="$SUBSCRIPTION_NAMES_JSON" --overwrite
+    fi
   when: item.metadata.name|regex_search(operators_regexp)
   loop: "{{ example_cnf_csv_list.resources }}"
 


### PR DESCRIPTION
This fix intends to solve a problem we are having in some daily jobs like this one:
https://www.distributed-ci.io/jobs/dbeabe85-6aab-4e9d-a012-636cf6a2ec36/jobStates#71726004-54dd-4ecf-92c2-2c6b0b3df7c0:file66
It may happen that installplans for a given operator is empty or returning more than one element, depending on how example-cnf installation was. Currently, we are only handling one installplan per operator checked, so with this, we will treat these cases in which we can have 0 or more than 1 installplans per operator.
This was tested manually in CLI and it works.