### PR TITLE
Fixing problem when deleting autodiscovery labels from restarted pods

### DIFF
--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/post-run.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/post-run.yml
@@ -1,13 +1,24 @@
 ---
 
-# Remove labels from pods - only the labels related to exclude connectivity features
+# Remove labels from pods - only the labels related to exclude connectivity features that are
+# currently present (because they may have been deleted because the pod has been restarted,
+# so we cannot rely on example_cnf_pod_list)
 
-- name: Remove autodiscovery labels related to exclude connectivity features from pods
+- name: Get pods from example-cnf namespace that have autodiscovery label defined
+  k8s_info:
+    api_version: v1
+    kind: pod
+    namespace: "{{ app_ns }}"
+    label_selectors:
+      - test-network-function.com/skip_connectivity_tests = true
+  register: example_cnf_labelled_pod_list
+
+- name: Remove autodiscovery labels related to exclude connectivity features from the corresponding pods
   shell: |
     set -ex
     oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/skip_connectivity_tests-
-  when:  item.metadata.name|regex_search(exclude_connectivity_regexp)
-  loop: "{{ example_cnf_pod_list.resources }}"
+  when: example_cnf_labelled_pod_list.resources|length > 0
+  loop: "{{ example_cnf_labelled_pod_list.resources }}"
 
 # Remove labels/annotations from operators
 


### PR DESCRIPTION
This issue appeared in this example-cnf daily job: https://www.distributed-ci.io/jobs/5865818c-251f-40c0-81b4-181eddd34ba7/jobStates#74caf31b-49f9-4cea-a972-7ec8ffaabf33:file179. What happened is that the pods from example-cnf namespace were restarted somehow after CNF Cert Suite execution, so that the task that removes the autodiscovery labels on the pods failed because they were not present.

With this change, we are relisting the pods from example-cnf, but just returning the pods that have the autodiscovery labels present, instead of relying on the pod list that was retrieved before executing the CNF Cert Suite.

This has been tested locally and works.