### PR TITLE
Retrieve more logs in the case of node update failure

### DIFF
--- a/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
+++ b/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
@@ -65,9 +65,19 @@
 - name: Retrieve more logs in the case of failure
   shell: |
     {{ oc_tool_path }} get mcp
+    echo "=========="
     {{ oc_tool_path }} get mc
+    echo "=========="
     {{ oc_tool_path }} describe mcp worker
+    echo "=========="
+    for i in {0..3}; do echo "worker-$i" && oc describe node worker-$i | grep Config; done
+  register: mcp_logs
   when: reg_mcpool_status.failed
+
+- name: Upload logs into DCI
+  copy:
+    dest: "{{ job_logs.path }}/cnf-example_mcp_failure_logs.log"
+    content: "{{ mcp_logs.stdout }}"
 
 - name: Fail when could not apply machine config on the nodes
   fail:

--- a/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
+++ b/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
@@ -44,43 +44,7 @@
     src: "{{ mrn_manifest_dir.path }}/imageContentSourcePolicy.yaml"
   notify: "Delete temporary directories"
 
-- name: "Wait for a moment to machine configs (if any) to render"
-  pause:
-    seconds: 60
+- name: Wait for updated MC to be applied on the nodes and retrieve logs
+  include_tasks: mcp_wait_and_logs.yml
 
-- name: Wait for updated machine configs to be applied on the nodes
-  k8s_info:
-    api_version: machineconfiguration.openshift.io/v1
-    kind: MachineConfigPool
-  register: reg_mcpool_status
-  vars:
-    status_query: "resources[*].status.conditions[?type=='Updated'].status"
-    update_status: "{{ reg_mcpool_status | json_query(status_query) | flatten | unique }}"
-  until:
-    - update_status == ['True']
-  retries: 60
-  delay: 60
-  ignore_errors: true
-
-- name: Retrieve more logs in the case of failure
-  shell: |
-    {{ oc_tool_path }} get mcp
-    echo "=========="
-    {{ oc_tool_path }} get mc
-    echo "=========="
-    {{ oc_tool_path }} describe mcp worker
-    echo "=========="
-    for i in {0..3}; do echo "worker-$i" && oc describe node worker-$i | grep Config; done
-  register: mcp_logs
-  when: reg_mcpool_status.failed
-
-- name: Upload logs into DCI
-  copy:
-    dest: "{{ job_logs.path }}/cnf-example_mcp_failure_logs.log"
-    content: "{{ mcp_logs.stdout }}"
-
-- name: Fail when could not apply machine config on the nodes
-  fail:
-    msg: "Failed to apply machine config on the nodes"
-  when: reg_mcpool_status.failed
 ...

--- a/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
+++ b/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
@@ -60,4 +60,17 @@
     - update_status == ['True']
   retries: 60
   delay: 60
+  ignore_errors: true
+
+- name: Retrieve more logs in the case of failure
+  shell: |
+    {{ oc_tool_path }} get mcp
+    {{ oc_tool_path }} get mc
+    {{ oc_tool_path }} describe mcp worker
+  when: reg_mcpool_status.failed
+
+- name: Fail when could not apply machine config on the nodes
+  fail:
+    msg: "Failed to apply machine config on the nodes"
+  when: reg_mcpool_status.failed
 ...

--- a/testpmd/hooks/roles/mirror-rh-nfv/tasks/mcp_wait_and_logs.yml
+++ b/testpmd/hooks/roles/mirror-rh-nfv/tasks/mcp_wait_and_logs.yml
@@ -1,0 +1,54 @@
+---
+- name: "Wait for a moment to machine configs (if any) to render"
+  pause:
+    seconds: 60
+
+- name: Wait for updated machine configs to be applied on the nodes
+  k8s_info:
+    api_version: machineconfiguration.openshift.io/v1
+    kind: MachineConfigPool
+  register: reg_mcpool_status
+  vars:
+    status_query: "resources[*].status.conditions[?type=='Updated'].status"
+    update_status: "{{ reg_mcpool_status | json_query(status_query) | flatten | unique }}"
+  until:
+    - update_status == ['True']
+  retries: 60
+  delay: 60
+  ignore_errors: true
+
+- name: Retrieve more logs in the case of failure
+  block:
+    - name: Retrieve mcp logs
+      shell: |
+        echo "oc get mcp =========="
+        {{ oc_tool_path }} get mcp
+        echo "oc get mc =========="
+        {{ oc_tool_path }} get mc
+        echo "oc describe mcp worker =========="
+        {{ oc_tool_path }} describe mcp worker
+      register: mcp_logs
+
+    - name: Retrieve list of worker nodes
+      shell: >
+        {{ oc_tool_path }} get nodes --selector=node-role.kubernetes.io/worker -o custom-columns=NAME:.metadata.name --no-headers
+      register: worker_nodes
+
+    - name: Retrieve worker logs
+      shell: |
+        echo "oc describe node {{ item }} =========="
+        {{ oc_tool_path }} describe node {{ item }}
+      loop: "{{ worker_nodes }}"
+      register: mcp_worker_logs
+
+    - name: Upload logs into DCI
+      copy:
+        dest: "{{ job_logs.path }}/cnf-example_mcp_failure_logs.log"
+        content: "{{ mcp_logs.stdout }} {{ mcp_worker_logs.stdout }}"
+
+    - name: Fail when could not apply machine config on the nodes
+      fail:
+        msg: "Failed to apply machine config on the nodes"
+  when: reg_mcpool_status.failed
+
+  ...


### PR DESCRIPTION
This PR is to [retrieve more logs](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html/post-installation_configuration/post-install-machine-configuration-tasks#checking-mco-status_post-install-machine-configuration-tasks) in the case of fail on "Wait for updated machine configs to be applied on the nodes".