### PR TITLE
[WIP] CNF with one PF per policy

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -77,7 +77,7 @@
     loop_var: sriov
   when: sriov_network is defined
 
-- name: "Create SriovNetwork for"
+- name: "Create SriovNetworks"
   k8s:
     definition: "{{ lookup('template', 'templates/sriov-network.yml.j2') }}"
   loop: "{{ sriov_network }}"

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -35,7 +35,7 @@
       - name: intel-numa0-net1
         count: 2
     packet_generator_networks:
-      - name: intel-numa0-net2
+      - name: intel-numa0-net1
         count: 2
     run_migration_test: false
     mac_workaround_enable: false
@@ -69,7 +69,7 @@
 #    rootdevices:
 #      - "0000:d8:00.0"
 #    nodeselector: '"node.openshift.io/nic_type": "intel810"'
-- name: "Create SriovNetworkNodePolicy for {{ sriov['policy'] }}"
+- name: "Create SriovNetworkNodePolicy"
   k8s:
     definition: "{{ lookup('template', 'templates/sriov-policy.yml.j2') }}"
   loop: "{{ sriov_network }}"
@@ -77,7 +77,7 @@
     loop_var: sriov
   when: sriov_network is defined
 
-- name: "Create SriovNetwork for {{ sriov['name'] }}"
+- name: "Create SriovNetwork for"
   k8s:
     definition: "{{ lookup('template', 'templates/sriov-network.yml.j2') }}"
   loop: "{{ sriov_network }}"

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -35,7 +35,7 @@
       - name: intel-numa0-net1
         count: 2
     packet_generator_networks:
-      - name: intel-numa0-net1
+      - name: intel-numa0-net2
         count: 2
     run_migration_test: false
     mac_workaround_enable: false

--- a/testpmd/hooks/templates/sriov-network.yml.j2
+++ b/testpmd/hooks/templates/sriov-network.yml.j2
@@ -1,7 +1,21 @@
+---
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:
-  name: "{{ sriov['name'] }}"
+  name: "intel-numa0-net1"
+  namespace: openshift-sriov-network-operator
+spec:
+  networkNamespace: "{{ cnf_namespace }}"
+  vlan: {{ sriov['vlan']|int }}
+  resourceName: "{{ sriov['resource'] }}"
+  spoofChk: "on"
+  trust: "on"
+  ipam: '{ }'
+---
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: "intel-numa0-net2"
   namespace: openshift-sriov-network-operator
 spec:
   networkNamespace: "{{ cnf_namespace }}"

--- a/testpmd/hooks/templates/sriov-network.yml.j2
+++ b/testpmd/hooks/templates/sriov-network.yml.j2
@@ -2,20 +2,7 @@
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:
-  name: "intel-numa0-net1"
-  namespace: openshift-sriov-network-operator
-spec:
-  networkNamespace: "{{ cnf_namespace }}"
-  vlan: {{ sriov['vlan']|int }}
-  resourceName: "{{ sriov['resource'] }}"
-  spoofChk: "on"
-  trust: "on"
-  ipam: '{ }'
----
-apiVersion: sriovnetwork.openshift.io/v1
-kind: SriovNetwork
-metadata:
-  name: "intel-numa0-net2"
+  name: "{{ sriov['name'] }}"
   namespace: openshift-sriov-network-operator
 spec:
   networkNamespace: "{{ cnf_namespace }}"


### PR DESCRIPTION
build-depends: https://github.com/dci-labs/inventories/pull/76
build-depends: https://github.com/dci-labs/dallas-pipelines/pull/242
build-depends: https://github.com/dci-labs/example-cnf-config/pull/46

Currently we create two policies, but both come from the same PF and they use the same VLAN, they only used diff VFs, this change is to test if we can use only one policy.