### PR TITLE
Using the OC clients defined by DOAA

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Create a pipeline file. For example:
       operator_version: v0.0.1
       app_version: v0.1.2
       repo_name: nfv-example-cnf
-      ocp_version: 4.5
+      ocp_version: 4.7
       enable_trex: true
     topic: OCP-4.5
     components: []

--- a/testpmd/hooks/files/collect-sriov-operator-data.sh
+++ b/testpmd/hooks/files/collect-sriov-operator-data.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo "Tool path: ${1}" 
+
 # Setting OC binary
 if [ -n "${1}" ]; then
  oc_tool_path=${1};

--- a/testpmd/hooks/files/collect-sriov-operator-data.sh
+++ b/testpmd/hooks/files/collect-sriov-operator-data.sh
@@ -4,56 +4,56 @@ NAMESPACE=openshift-sriov-network-operator
 
 echo "=== Overview ===" 
 
-{{ app_agent_dir.path }}/oc get pods -n $NAMESPACE
-{{ app_agent_dir.path }}/oc get deployments -n $NAMESPACE
-{{ app_agent_dir.path }}/oc get replicasets -n $NAMESPACE
-{{ app_agent_dir.path }}/oc get daemonsets -n $NAMESPACE
+{{ oc_tool_path }} get pods -n $NAMESPACE
+{{ oc_tool_path }} get deployments -n $NAMESPACE
+{{ oc_tool_path }} get replicasets -n $NAMESPACE
+{{ oc_tool_path }} get daemonsets -n $NAMESPACE
 
-{{ app_agent_dir.path }}/oc get csv -n $NAMESPACE
-{{ app_agent_dir.path }}/oc get operatorgroup -n $NAMESPACE
+{{ oc_tool_path }} get csv -n $NAMESPACE
+{{ oc_tool_path }} get operatorgroup -n $NAMESPACE
 
-{{ app_agent_dir.path }}/oc get SriovOperatorConfig -n $NAMESPACE
-{{ app_agent_dir.path }}/oc get SriovNetwork -n $NAMESPACE
-{{ app_agent_dir.path }}/oc get SriovNetworkNodeState -n $NAMESPACE
-{{ app_agent_dir.path }}/oc get SriovNetworkNodePolicy -n $NAMESPACE
+{{ oc_tool_path }} get SriovOperatorConfig -n $NAMESPACE
+{{ oc_tool_path }} get SriovNetwork -n $NAMESPACE
+{{ oc_tool_path }} get SriovNetworkNodeState -n $NAMESPACE
+{{ oc_tool_path }} get SriovNetworkNodePolicy -n $NAMESPACE
 
 echo "=== -o yaml ==="
 
-{{ app_agent_dir.path }}/oc get -o yaml pods -n $NAMESPACE
-{{ app_agent_dir.path }}/oc get -o yaml deployments -n $NAMESPACE
-{{ app_agent_dir.path }}/oc get -o yaml replicasets -n $NAMESPACE
-{{ app_agent_dir.path }}/oc get -o yaml daemonsets -n $NAMESPACE
+{{ oc_tool_path }} get -o yaml pods -n $NAMESPACE
+{{ oc_tool_path }} get -o yaml deployments -n $NAMESPACE
+{{ oc_tool_path }} get -o yaml replicasets -n $NAMESPACE
+{{ oc_tool_path }} get -o yaml daemonsets -n $NAMESPACE
 
-{{ app_agent_dir.path }}/oc get -o yaml csv -n $NAMESPACE
-{{ app_agent_dir.path }}/oc get -o yaml operatorgroup -n $NAMESPACE
+{{ oc_tool_path }} get -o yaml csv -n $NAMESPACE
+{{ oc_tool_path }} get -o yaml operatorgroup -n $NAMESPACE
 
-{{ app_agent_dir.path }}/oc get -o yaml SriovOperatorConfig -n $NAMESPACE
-{{ app_agent_dir.path }}/oc get -o yaml SriovNetwork -n $NAMESPACE
-{{ app_agent_dir.path }}/oc get -o yaml SriovNetworkNodeState -n $NAMESPACE
-{{ app_agent_dir.path }}/oc get -o yaml SriovNetworkNodePolicy -n $NAMESPACE
+{{ oc_tool_path }} get -o yaml SriovOperatorConfig -n $NAMESPACE
+{{ oc_tool_path }} get -o yaml SriovNetwork -n $NAMESPACE
+{{ oc_tool_path }} get -o yaml SriovNetworkNodeState -n $NAMESPACE
+{{ oc_tool_path }} get -o yaml SriovNetworkNodePolicy -n $NAMESPACE
 
 echo "=== describe ==="
 
-{{ app_agent_dir.path }}/oc describe pods -n $NAMESPACE
-{{ app_agent_dir.path }}/oc describe deployments -n $NAMESPACE
-{{ app_agent_dir.path }}/oc describe replicasets -n $NAMESPACE
-{{ app_agent_dir.path }}/oc describe daemonsets -n $NAMESPACE
+{{ oc_tool_path }} describe pods -n $NAMESPACE
+{{ oc_tool_path }} describe deployments -n $NAMESPACE
+{{ oc_tool_path }} describe replicasets -n $NAMESPACE
+{{ oc_tool_path }} describe daemonsets -n $NAMESPACE
 
-{{ app_agent_dir.path }}/oc describe csv -n $NAMESPACE
-{{ app_agent_dir.path }}/oc describe operatorgroup -n $NAMESPACE
+{{ oc_tool_path }} describe csv -n $NAMESPACE
+{{ oc_tool_path }} describe operatorgroup -n $NAMESPACE
 
-{{ app_agent_dir.path }}/oc describe SriovOperatorConfig -n $NAMESPACE
-{{ app_agent_dir.path }}/oc describe SriovNetwork -n $NAMESPACE
-{{ app_agent_dir.path }}/oc describe SriovNetworkNodeState -n $NAMESPACE
-{{ app_agent_dir.path }}/oc describe SriovNetworkNodePolicy -n $NAMESPACE
+{{ oc_tool_path }} describe SriovOperatorConfig -n $NAMESPACE
+{{ oc_tool_path }} describe SriovNetwork -n $NAMESPACE
+{{ oc_tool_path }} describe SriovNetworkNodeState -n $NAMESPACE
+{{ oc_tool_path }} describe SriovNetworkNodePolicy -n $NAMESPACE
 
 echo "=== Collecting node info ==="
-{{ app_agent_dir.path }}/oc get nodes -o yaml
+{{ oc_tool_path }} get nodes -o yaml
 
 echo "=== Collecting logs ==="
-for pod in $({{ app_agent_dir.path }}/oc get pods -n $NAMESPACE -o name); do 
+for pod in $({{ oc_tool_path }} get pods -n $NAMESPACE -o name); do 
   echo "+++ logs for pod $pod +++"
-  {{ app_agent_dir.path }}/oc logs -n $NAMESPACE $pod
+  {{ oc_tool_path }} logs -n $NAMESPACE $pod
 done
 
 EOF

--- a/testpmd/hooks/files/collect-sriov-operator-data.sh
+++ b/testpmd/hooks/files/collect-sriov-operator-data.sh
@@ -4,12 +4,12 @@
 if [ -n "${1}" ]; then
  oc_tool_path=${1};
 else
-  if ! command -v oc &> /dev/null
+  if ! type -P oc &> /dev/null
   then
       echo "oc could not be found"
       exit
   else
-      oc_tool_path=$(command -v oc)
+      oc_tool_path=$(type -P oc)
   fi
 fi
 

--- a/testpmd/hooks/files/collect-sriov-operator-data.sh
+++ b/testpmd/hooks/files/collect-sriov-operator-data.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set +x
+
 echo "Tool path: ${1}" 
 
 # Setting OC binary

--- a/testpmd/hooks/files/collect-sriov-operator-data.sh
+++ b/testpmd/hooks/files/collect-sriov-operator-data.sh
@@ -4,56 +4,56 @@ NAMESPACE=openshift-sriov-network-operator
 
 echo "=== Overview ===" 
 
-oc get pods -n $NAMESPACE
-oc get deployments -n $NAMESPACE
-oc get replicasets -n $NAMESPACE
-oc get daemonsets -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get pods -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get deployments -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get replicasets -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get daemonsets -n $NAMESPACE
 
-oc get csv -n $NAMESPACE
-oc get operatorgroup -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get csv -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get operatorgroup -n $NAMESPACE
 
-oc get SriovOperatorConfig -n $NAMESPACE
-oc get SriovNetwork -n $NAMESPACE
-oc get SriovNetworkNodeState -n $NAMESPACE
-oc get SriovNetworkNodePolicy -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get SriovOperatorConfig -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get SriovNetwork -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get SriovNetworkNodeState -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get SriovNetworkNodePolicy -n $NAMESPACE
 
 echo "=== -o yaml ==="
 
-oc get -o yaml pods -n $NAMESPACE
-oc get -o yaml deployments -n $NAMESPACE
-oc get -o yaml replicasets -n $NAMESPACE
-oc get -o yaml daemonsets -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get -o yaml pods -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get -o yaml deployments -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get -o yaml replicasets -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get -o yaml daemonsets -n $NAMESPACE
 
-oc get -o yaml csv -n $NAMESPACE
-oc get -o yaml operatorgroup -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get -o yaml csv -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get -o yaml operatorgroup -n $NAMESPACE
 
-oc get -o yaml SriovOperatorConfig -n $NAMESPACE
-oc get -o yaml SriovNetwork -n $NAMESPACE
-oc get -o yaml SriovNetworkNodeState -n $NAMESPACE
-oc get -o yaml SriovNetworkNodePolicy -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get -o yaml SriovOperatorConfig -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get -o yaml SriovNetwork -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get -o yaml SriovNetworkNodeState -n $NAMESPACE
+{{ app_agent_dir.path }}/oc get -o yaml SriovNetworkNodePolicy -n $NAMESPACE
 
 echo "=== describe ==="
 
-oc describe pods -n $NAMESPACE
-oc describe deployments -n $NAMESPACE
-oc describe replicasets -n $NAMESPACE
-oc describe daemonsets -n $NAMESPACE
+{{ app_agent_dir.path }}/oc describe pods -n $NAMESPACE
+{{ app_agent_dir.path }}/oc describe deployments -n $NAMESPACE
+{{ app_agent_dir.path }}/oc describe replicasets -n $NAMESPACE
+{{ app_agent_dir.path }}/oc describe daemonsets -n $NAMESPACE
 
-oc describe csv -n $NAMESPACE
-oc describe operatorgroup -n $NAMESPACE
+{{ app_agent_dir.path }}/oc describe csv -n $NAMESPACE
+{{ app_agent_dir.path }}/oc describe operatorgroup -n $NAMESPACE
 
-oc describe SriovOperatorConfig -n $NAMESPACE
-oc describe SriovNetwork -n $NAMESPACE
-oc describe SriovNetworkNodeState -n $NAMESPACE
-oc describe SriovNetworkNodePolicy -n $NAMESPACE
+{{ app_agent_dir.path }}/oc describe SriovOperatorConfig -n $NAMESPACE
+{{ app_agent_dir.path }}/oc describe SriovNetwork -n $NAMESPACE
+{{ app_agent_dir.path }}/oc describe SriovNetworkNodeState -n $NAMESPACE
+{{ app_agent_dir.path }}/oc describe SriovNetworkNodePolicy -n $NAMESPACE
 
 echo "=== Collecting node info ==="
-oc get nodes -o yaml
+{{ app_agent_dir.path }}/oc get nodes -o yaml
 
 echo "=== Collecting logs ==="
-for pod in $(oc get pods -n $NAMESPACE -o name); do 
+for pod in $({{ app_agent_dir.path }}/oc get pods -n $NAMESPACE -o name); do 
   echo "+++ logs for pod $pod +++"
-  oc logs -n $NAMESPACE $pod
+  {{ app_agent_dir.path }}/oc logs -n $NAMESPACE $pod
 done
 
 EOF

--- a/testpmd/hooks/files/collect-sriov-operator-data.sh
+++ b/testpmd/hooks/files/collect-sriov-operator-data.sh
@@ -1,59 +1,72 @@
-#!/bin/bash 
+#!/bin/bash
+
+# Setting OC binary
+if [ -n "${1}" ]; then
+ oc_tool_path=${1};
+else
+  if ! command -v oc &> /dev/null
+  then
+      echo "oc could not be found"
+      exit
+  else
+      oc_tool_path=$(command -v oc)
+  fi
+fi
 
 NAMESPACE=openshift-sriov-network-operator
 
 echo "=== Overview ===" 
 
-{{ oc_tool_path }} get pods -n $NAMESPACE
-{{ oc_tool_path }} get deployments -n $NAMESPACE
-{{ oc_tool_path }} get replicasets -n $NAMESPACE
-{{ oc_tool_path }} get daemonsets -n $NAMESPACE
+${oc_tool_path} get pods -n $NAMESPACE
+${oc_tool_path} get deployments -n $NAMESPACE
+${oc_tool_path} get replicasets -n $NAMESPACE
+${oc_tool_path} get daemonsets -n $NAMESPACE
 
-{{ oc_tool_path }} get csv -n $NAMESPACE
-{{ oc_tool_path }} get operatorgroup -n $NAMESPACE
+${oc_tool_path} get csv -n $NAMESPACE
+${oc_tool_path} get operatorgroup -n $NAMESPACE
 
-{{ oc_tool_path }} get SriovOperatorConfig -n $NAMESPACE
-{{ oc_tool_path }} get SriovNetwork -n $NAMESPACE
-{{ oc_tool_path }} get SriovNetworkNodeState -n $NAMESPACE
-{{ oc_tool_path }} get SriovNetworkNodePolicy -n $NAMESPACE
+${oc_tool_path} get SriovOperatorConfig -n $NAMESPACE
+${oc_tool_path} get SriovNetwork -n $NAMESPACE
+${oc_tool_path} get SriovNetworkNodeState -n $NAMESPACE
+${oc_tool_path} get SriovNetworkNodePolicy -n $NAMESPACE
 
 echo "=== -o yaml ==="
 
-{{ oc_tool_path }} get -o yaml pods -n $NAMESPACE
-{{ oc_tool_path }} get -o yaml deployments -n $NAMESPACE
-{{ oc_tool_path }} get -o yaml replicasets -n $NAMESPACE
-{{ oc_tool_path }} get -o yaml daemonsets -n $NAMESPACE
+${oc_tool_path} get -o yaml pods -n $NAMESPACE
+${oc_tool_path} get -o yaml deployments -n $NAMESPACE
+${oc_tool_path} get -o yaml replicasets -n $NAMESPACE
+${oc_tool_path} get -o yaml daemonsets -n $NAMESPACE
 
-{{ oc_tool_path }} get -o yaml csv -n $NAMESPACE
-{{ oc_tool_path }} get -o yaml operatorgroup -n $NAMESPACE
+${oc_tool_path} get -o yaml csv -n $NAMESPACE
+${oc_tool_path} get -o yaml operatorgroup -n $NAMESPACE
 
-{{ oc_tool_path }} get -o yaml SriovOperatorConfig -n $NAMESPACE
-{{ oc_tool_path }} get -o yaml SriovNetwork -n $NAMESPACE
-{{ oc_tool_path }} get -o yaml SriovNetworkNodeState -n $NAMESPACE
-{{ oc_tool_path }} get -o yaml SriovNetworkNodePolicy -n $NAMESPACE
+${oc_tool_path} get -o yaml SriovOperatorConfig -n $NAMESPACE
+${oc_tool_path} get -o yaml SriovNetwork -n $NAMESPACE
+${oc_tool_path} get -o yaml SriovNetworkNodeState -n $NAMESPACE
+${oc_tool_path} get -o yaml SriovNetworkNodePolicy -n $NAMESPACE
 
 echo "=== describe ==="
 
-{{ oc_tool_path }} describe pods -n $NAMESPACE
-{{ oc_tool_path }} describe deployments -n $NAMESPACE
-{{ oc_tool_path }} describe replicasets -n $NAMESPACE
-{{ oc_tool_path }} describe daemonsets -n $NAMESPACE
+${oc_tool_path} describe pods -n $NAMESPACE
+${oc_tool_path} describe deployments -n $NAMESPACE
+${oc_tool_path} describe replicasets -n $NAMESPACE
+${oc_tool_path} describe daemonsets -n $NAMESPACE
 
-{{ oc_tool_path }} describe csv -n $NAMESPACE
-{{ oc_tool_path }} describe operatorgroup -n $NAMESPACE
+${oc_tool_path} describe csv -n $NAMESPACE
+${oc_tool_path} describe operatorgroup -n $NAMESPACE
 
-{{ oc_tool_path }} describe SriovOperatorConfig -n $NAMESPACE
-{{ oc_tool_path }} describe SriovNetwork -n $NAMESPACE
-{{ oc_tool_path }} describe SriovNetworkNodeState -n $NAMESPACE
-{{ oc_tool_path }} describe SriovNetworkNodePolicy -n $NAMESPACE
+${oc_tool_path} describe SriovOperatorConfig -n $NAMESPACE
+${oc_tool_path} describe SriovNetwork -n $NAMESPACE
+${oc_tool_path} describe SriovNetworkNodeState -n $NAMESPACE
+${oc_tool_path} describe SriovNetworkNodePolicy -n $NAMESPACE
 
 echo "=== Collecting node info ==="
-{{ oc_tool_path }} get nodes -o yaml
+${oc_tool_path} get nodes -o yaml
 
 echo "=== Collecting logs ==="
-for pod in $({{ oc_tool_path }} get pods -n $NAMESPACE -o name); do 
+for pod in $(${oc_tool_path} get pods -n $NAMESPACE -o name); do
   echo "+++ logs for pod $pod +++"
-  {{ oc_tool_path }} logs -n $NAMESPACE $pod
+  ${oc_tool_path} logs -n $NAMESPACE $pod
 done
 
 EOF

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -3,11 +3,6 @@
   set_fact:
     cnf_namespace: "example-cnf"
 
-- name: Get oc version output
-  shell: |
-    {{ oc_tool_path }} --kubeconfig {{ kubeconfig_path }} version
-  register: oc_version_str
-
 - name: Get example-cnf component details from job.components
   set_fact:
     operator_version: "{{ item['name'] }}"

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -84,20 +84,16 @@
 
     - name: Delete all pods sriov-network-config-daemon-XXXXX
       shell: >
-        {{ oc_tool_path }} get pods -n {{ cnf_namespace }} --no-headers=true |
+        {{ oc_tool_path }} get pods -n openshift-sriov-network-operator --no-headers=true |
         awk '/sriov-network-config-daemon/{print $1}' |
-        xargs {{ oc_tool_path }} delete -n {{ cnf_namespace }} pod
+        xargs {{ oc_tool_path }} delete -n openshift-sriov-network-operator pod
 
     - name: Wait again to have all networks allocatable on worker nodes
       include_role:
         name: "{{ dci_config_dir }}/hooks/roles/sriov-networks"
 
 - name: SR-IOV must-gather
-<<<<<<< HEAD
-  script: ./{{ dci_config_dir }}/hooks/files/collect-sriov-operator-data.sh {{  }} | tee {{ job_logs.path }}/collect-sriov-operator-data.txt
-=======
-  script: ./{{ dci_config_dir }}/hooks/files/collect-sriov-operator-data.sh {{ oc_tool_path }} | tee {{ job_logs.path }}/collect-sriov-operator-data.txt
->>>>>>> f7b11f1 (Using the proper oc path)
+  script: "{{ dci_config_dir }}/hooks/files/collect-sriov-operator-data.sh {{ oc_tool_path }} | tee {{ job_logs.path }}/collect-sriov-operator-data.txt"
   ignore_errors: true
 
 - name: Checkout Example CNF deployment role

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -8,19 +8,6 @@
     {{ oc_tool_path }} --kubeconfig {{ kubeconfig_path }} version
   register: oc_version_str
 
-- name: Get OCP version
-  set_fact:
-    ocp_version: "{{ '.'.join(item.split(':')[1].strip().split('.')[0:2]) }}"
-    ocp_version_maj: "{{ item.split(':')[1].strip().split('.')[0] }}"
-    ocp_version_min: "{{ item.split(':')[1].strip().split('.')[1] }}"
-  when: "'Server Version' in item"
-  loop: "{{ oc_version_str.stdout_lines }}"
-
-- name: Fail if the ocp version is not set
-  fail:
-    msg: "OCP version is not set"
-  when: not ocp_version
-
 - name: Get example-cnf component details from job.components
   set_fact:
     operator_version: "{{ item['name'] }}"
@@ -114,13 +101,6 @@
   shell: >
     bash {{ dci_config_dir }}/hooks/files/collect-sriov-operator-data.sh | tee {{ job_logs.path }}/collect-sriov-operator-data-ok.txt
   ignore_errors: true
-
-- name: Set mac workround for ocp older than 4.6
-  set_fact:
-    mac_workaround_enable: true
-  when:
-    - ocp_version_maj|int == 4
-    - ocp_version_min|int < 6
 
 - name: Checkout Example CNF deployment role
   git:

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -84,17 +84,16 @@
 
     - name: Delete all pods sriov-network-config-daemon-XXXXX
       shell: >
-        {{ oc_tool_path }} get pods -n openshift-sriov-network-operator --no-headers=true |
+        {{ oc_tool_path }} get pods -n {{ cnf_namespace }} --no-headers=true |
         awk '/sriov-network-config-daemon/{print $1}' |
-        xargs {{ oc_tool_path }} delete -n openshift-sriov-network-operator pod
+        xargs {{ oc_tool_path }} delete -n {{ cnf_namespace }} pod
 
     - name: Wait again to have all networks allocatable on worker nodes
       include_role:
         name: "{{ dci_config_dir }}/hooks/roles/sriov-networks"
 
 - name: SR-IOV must-gather
-  shell: >
-    bash {{ dci_config_dir }}/hooks/files/collect-sriov-operator-data.sh | tee {{ job_logs.path }}/collect-sriov-operator-data-ok.txt
+  script: ./{{ dci_config_dir }}/hooks/files/collect-sriov-operator-data.sh {{  }} | tee {{ job_logs.path }}/collect-sriov-operator-data.txt
   ignore_errors: true
 
 - name: Checkout Example CNF deployment role

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -84,9 +84,9 @@
 
     - name: Delete all pods sriov-network-config-daemon-XXXXX
       shell: >
-        oc get pods -n openshift-sriov-network-operator --no-headers=true |
+        {{ oc_tool_path }} get pods -n openshift-sriov-network-operator --no-headers=true |
         awk '/sriov-network-config-daemon/{print $1}' |
-        xargs oc delete -n openshift-sriov-network-operator pod
+        xargs {{ oc_tool_path }} delete -n openshift-sriov-network-operator pod
 
     - name: Wait again to have all networks allocatable on worker nodes
       include_role:

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -93,7 +93,11 @@
         name: "{{ dci_config_dir }}/hooks/roles/sriov-networks"
 
 - name: SR-IOV must-gather
+<<<<<<< HEAD
   script: ./{{ dci_config_dir }}/hooks/files/collect-sriov-operator-data.sh {{  }} | tee {{ job_logs.path }}/collect-sriov-operator-data.txt
+=======
+  script: ./{{ dci_config_dir }}/hooks/files/collect-sriov-operator-data.sh {{ oc_tool_path }} | tee {{ job_logs.path }}/collect-sriov-operator-data.txt
+>>>>>>> f7b11f1 (Using the proper oc path)
   ignore_errors: true
 
 - name: Checkout Example CNF deployment role

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/install.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/install.yml
@@ -18,7 +18,7 @@
 - name: Tag pods with autodiscovery labels related to exclude connectivity features in test suites
   shell: |
     set -ex
-    oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/skip_connectivity_tests=true --overwrite
+    {{ app_agent_dir.path }}/oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/skip_connectivity_tests=true --overwrite
   when:  item.metadata.name|regex_search(exclude_connectivity_regexp)
   loop: "{{ example_cnf_pod_list.resources }}"
 
@@ -36,19 +36,19 @@
   shell: |
     set -ex
     
-    oc label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator=target --overwrite
-    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests='["OPERATOR_STATUS"]' --overwrite
+    {{ app_agent_dir.path }}/oc label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator=target --overwrite
+    {{ app_agent_dir.path }}/oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests='["OPERATOR_STATUS"]' --overwrite
     
-    INSTALL_PLAN_NAMES=($(oc get installplan -n "{{ app_ns }}" | grep "{{ item.metadata.name }}" | awk '{ print $1 }'))
+    INSTALL_PLAN_NAMES=($({{ app_agent_dir.path }}/oc get installplan -n "{{ app_ns }}" | grep "{{ item.metadata.name }}" | awk '{ print $1 }'))
     INSTALL_PLAN_NUMBER=$(echo -n ${INSTALL_PLAN_NAMES[@]} | wc -w)
 
     if [ $INSTALL_PLAN_NUMBER -ne 0 ]; then
       SUBSCRIPTION_NAMES=()
       for INSTALL_PLAN_NAME in "${INSTALL_PLAN_NAMES[@]}"; do
-        SUBSCRIPTION_NAMES+=( $(oc get installplan "${INSTALL_PLAN_NAME}" -n "{{ app_ns }}" -o json | jq -r ".metadata.ownerReferences[].name") )
+        SUBSCRIPTION_NAMES+=( $({{ app_agent_dir.path }}/oc get installplan "${INSTALL_PLAN_NAME}" -n "{{ app_ns }}" -o json | jq -r ".metadata.ownerReferences[].name") )
       done
       SUBSCRIPTION_NAMES_JSON=$(echo ${SUBSCRIPTION_NAMES[@]} | jq -R 'split (" ")| unique')
-      oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name="$SUBSCRIPTION_NAMES_JSON" --overwrite
+      {{ app_agent_dir.path }}/oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name="$SUBSCRIPTION_NAMES_JSON" --overwrite
     fi
   when: item.metadata.name|regex_search(operators_regexp)
   loop: "{{ example_cnf_csv_list.resources }}"

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/install.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/install.yml
@@ -18,7 +18,7 @@
 - name: Tag pods with autodiscovery labels related to exclude connectivity features in test suites
   shell: |
     set -ex
-    {{ app_agent_dir.path }}/oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/skip_connectivity_tests=true --overwrite
+    {{ oc_tool_path }} label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/skip_connectivity_tests=true --overwrite
   when:  item.metadata.name|regex_search(exclude_connectivity_regexp)
   loop: "{{ example_cnf_pod_list.resources }}"
 
@@ -36,19 +36,19 @@
   shell: |
     set -ex
     
-    {{ app_agent_dir.path }}/oc label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator=target --overwrite
-    {{ app_agent_dir.path }}/oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests='["OPERATOR_STATUS"]' --overwrite
+    {{ oc_tool_path }} label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator=target --overwrite
+    {{ oc_tool_path }} annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests='["OPERATOR_STATUS"]' --overwrite
     
-    INSTALL_PLAN_NAMES=($({{ app_agent_dir.path }}/oc get installplan -n "{{ app_ns }}" | grep "{{ item.metadata.name }}" | awk '{ print $1 }'))
+    INSTALL_PLAN_NAMES=($({{ oc_tool_path }} get installplan -n "{{ app_ns }}" | grep "{{ item.metadata.name }}" | awk '{ print $1 }'))
     INSTALL_PLAN_NUMBER=$(echo -n ${INSTALL_PLAN_NAMES[@]} | wc -w)
 
     if [ $INSTALL_PLAN_NUMBER -ne 0 ]; then
       SUBSCRIPTION_NAMES=()
       for INSTALL_PLAN_NAME in "${INSTALL_PLAN_NAMES[@]}"; do
-        SUBSCRIPTION_NAMES+=( $({{ app_agent_dir.path }}/oc get installplan "${INSTALL_PLAN_NAME}" -n "{{ app_ns }}" -o json | jq -r ".metadata.ownerReferences[].name") )
+        SUBSCRIPTION_NAMES+=( $({{ oc_tool_path }} get installplan "${INSTALL_PLAN_NAME}" -n "{{ app_ns }}" -o json | jq -r ".metadata.ownerReferences[].name") )
       done
       SUBSCRIPTION_NAMES_JSON=$(echo ${SUBSCRIPTION_NAMES[@]} | jq -R 'split (" ")| unique')
-      {{ app_agent_dir.path }}/oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name="$SUBSCRIPTION_NAMES_JSON" --overwrite
+      {{ oc_tool_path }} annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name="$SUBSCRIPTION_NAMES_JSON" --overwrite
     fi
   when: item.metadata.name|regex_search(operators_regexp)
   loop: "{{ example_cnf_csv_list.resources }}"

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/post-run.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/post-run.yml
@@ -16,7 +16,7 @@
 - name: Remove autodiscovery labels related to exclude connectivity features from the corresponding pods
   shell: |
     set -ex
-    {{ app_agent_dir.path }}/oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/skip_connectivity_tests-
+    {{ oc_tool_path }} label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/skip_connectivity_tests-
   when: example_cnf_labelled_pod_list.resources|length > 0
   loop: "{{ example_cnf_labelled_pod_list.resources }}"
 
@@ -26,9 +26,9 @@
   shell: |
     set -ex
     
-    {{ app_agent_dir.path }}/oc label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator-
-    {{ app_agent_dir.path }}/oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests-
-    {{ app_agent_dir.path }}/oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name-
+    {{ oc_tool_path }} label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator-
+    {{ oc_tool_path }} annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests-
+    {{ oc_tool_path }} annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name-
   when: item.metadata.name|regex_search(operators_regexp)
   loop: "{{ example_cnf_csv_list.resources }}"
 

--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/post-run.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/post-run.yml
@@ -16,7 +16,7 @@
 - name: Remove autodiscovery labels related to exclude connectivity features from the corresponding pods
   shell: |
     set -ex
-    oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/skip_connectivity_tests-
+    {{ app_agent_dir.path }}/oc label pod -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/skip_connectivity_tests-
   when: example_cnf_labelled_pod_list.resources|length > 0
   loop: "{{ example_cnf_labelled_pod_list.resources }}"
 
@@ -26,9 +26,9 @@
   shell: |
     set -ex
     
-    oc label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator-
-    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests-
-    oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name-
+    {{ app_agent_dir.path }}/oc label csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator-
+    {{ app_agent_dir.path }}/oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/operator_tests-
+    {{ app_agent_dir.path }}/oc annotate csv -n "{{ app_ns }}" "{{ item.metadata.name }}" test-network-function.com/subscription_name-
   when: item.metadata.name|regex_search(operators_regexp)
   loop: "{{ example_cnf_csv_list.resources }}"
 

--- a/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
+++ b/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: "Mirror images from index"
   shell:
     cmd: >
-      oc adm catalog mirror
+      {{ app_agent_dir.path }}/oc adm catalog mirror
       -a {{ mrn_pull_secret }}
       --to-manifests={{ mrn_manifest_dir.path }}
       {{ mrn_mirror_index_image }}

--- a/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
+++ b/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: "Mirror images from index"
   shell:
     cmd: >
-      {{ app_agent_dir.path }}/oc adm catalog mirror
+      {{ oc_tool_path }} adm catalog mirror
       -a {{ mrn_pull_secret }}
       --to-manifests={{ mrn_manifest_dir.path }}
       {{ mrn_mirror_index_image }}

--- a/testpmd/hooks/roles/sriov-networks/tasks/main.yml
+++ b/testpmd/hooks/roles/sriov-networks/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Get number of workers
   shell: >
-    {{ app_agent_dir.path }}/oc get nodes --no-headers=true --selector='!node-role.kubernetes.io/master' | wc -l
+    {{ oc_tool_path }} get nodes --no-headers=true --selector='!node-role.kubernetes.io/master' | wc -l
   register: count_workers
 
 - name: Wait to have all networks allocatable on worker nodes
   shell: >
-    {{ app_agent_dir.path }}/oc get nodes --selector='!node-role.kubernetes.io/master' -o jsonpath='{.items[*].status.allocatable}'
+    {{ oc_tool_path }} get nodes --selector='!node-role.kubernetes.io/master' -o jsonpath='{.items[*].status.allocatable}'
   register: nodes_allocation
   until:
     - nodes_allocation.stdout | regex_findall(sriov_network[0].resource) | length == count_workers.stdout | int

--- a/testpmd/hooks/roles/sriov-networks/tasks/main.yml
+++ b/testpmd/hooks/roles/sriov-networks/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Get number of workers
   shell: >
-    oc get nodes --no-headers=true --selector='!node-role.kubernetes.io/master' | wc -l
+    {{ app_agent_dir.path }}/oc get nodes --no-headers=true --selector='!node-role.kubernetes.io/master' | wc -l
   register: count_workers
 
 - name: Wait to have all networks allocatable on worker nodes
   shell: >
-    oc get nodes --selector='!node-role.kubernetes.io/master' -o jsonpath='{.items[*].status.allocatable}'
+    {{ app_agent_dir.path }}/oc get nodes --selector='!node-role.kubernetes.io/master' -o jsonpath='{.items[*].status.allocatable}'
   register: nodes_allocation
   until:
     - nodes_allocation.stdout | regex_findall(sriov_network[0].resource) | length == count_workers.stdout | int


### PR DESCRIPTION
- Using the clients used by DOAA
- Information about OCP version is provided by the agent already
- The check for 4.5 is not needed anymore as it is unsupported

build-depends: 24117
