### PR TITLE
Replace MCP check by wait-mcp common role

### DIFF
--- a/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
+++ b/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
@@ -48,16 +48,11 @@
   pause:
     seconds: 60
 
-- name: Wait for updated machine configs to be applied on the nodes
-  k8s_info:
-    api_version: machineconfiguration.openshift.io/v1
-    kind: MachineConfigPool
-  register: reg_mcpool_status
+- name: Wait for MCP status
+  include_role:
+    name: wait-mcp
   vars:
-    status_query: "resources[*].status.conditions[?type=='Updated'].status"
-    update_status: "{{ reg_mcpool_status | json_query(status_query) | flatten | unique }}"
-  until:
-    - update_status == ['True']
-  retries: 60
-  delay: 60
+    mcp_wait_retries: 60
+    mcp_wait_delay: 60
+
 ...

--- a/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
+++ b/testpmd/hooks/roles/mirror-rh-nfv/tasks/main.yml
@@ -44,10 +44,6 @@
     src: "{{ mrn_manifest_dir.path }}/imageContentSourcePolicy.yaml"
   notify: "Delete temporary directories"
 
-- name: "Wait for a moment to machine configs (if any) to render"
-  pause:
-    seconds: 60
-
 - name: Wait for MCP status
   include_role:
     name: wait-mcp


### PR DESCRIPTION
The usage of wait-mcp common role was missed in mirror-rh-nfv main task, and its absence (because wait-mcp applies the workaround if needed) is causing CILAB-409 to appear: https://www.distributed-ci.io/jobs/60065809-ab7d-4b6d-9808-341ec40701dd/jobStates