### PR TITLE
Use trex-container-app working on OCP-4.12

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -12,7 +12,7 @@
 
 - name: Create example-cnf facts
   set_fact:
-    app_version: v0.2.3
+    app_version: v0.2.6
     cnf_app_networks:
       - name: intel-numa0-net1
         count: 2


### PR DESCRIPTION
PR number 5.
This pull request is to use new [trex-container-app](https://github.com/rh-nfv-int/trex-container-app/pull/2) in the config of example-cnf.

Dependency: [the changes in deployment](https://github.com/rh-nfv-int/nfv-example-cnf-deploy/pull/30) should be merged first.

The change is tested on 4.7 - 4.13, here is the job for 4.12: https://www.distributed-ci.io/jobs/2b446378-c588-45e5-bf1d-902b407e2779/jobStates?sort=date
All the other links are in cilab-291.