### PR TITLE
Enable migration tests

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -19,7 +19,6 @@
     packet_generator_networks:
       - name: intel-numa0-net2
         count: 2
-    run_migration_test: false
     mac_workaround_enable: false
 
 - name: "Create CNF Namespace"


### PR DESCRIPTION
Should enable migration tests after the install of T-REX and Testpmd.
It should simulate the downtime of one node and we should see the migration of the app from one node to another.