### PR TITLE
List all workers to track a weird issue with 11 workers

### DIFF
--- a/testpmd/hooks/roles/sriov-networks/tasks/main.yml
+++ b/testpmd/hooks/roles/sriov-networks/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: List all workers
+  shell: >
+    {{ oc_tool_path }} get nodes --no-headers=true --selector='!node-role.kubernetes.io/master'
+
 - name: Get number of workers
   shell: >
     {{ oc_tool_path }} get nodes --no-headers=true --selector='!node-role.kubernetes.io/master' | wc -l


### PR DESCRIPTION
We got a weird issue when the standard command 
```$ oc get nodes --no-headers=true --selector='!node-role.kubernetes.io/master' | wc -l``` 
somehow detects 11 workers: https://www.distributed-ci.io/jobs/5fa4a100-6c35-4c59-9fa7-a4a641f00740/jobStates?sort=date&task=22475b4b-5fca-41e7-9342-c39ff6557d27 

The direct verification on the cluster provided no clue about the issue:
```
$ oc get nodes --no-headers=true --selector='!node-role.kubernetes.io/master'
worker-0   Ready   worker   3h40m   v1.23.12+8a6bfe4
worker-1   Ready   worker   3h39m   v1.23.12+8a6bfe4
worker-2   Ready   worker   3h40m   v1.23.12+8a6bfe4
worker-3   Ready   worker   3h40m   v1.23.12+8a6bfe4

$ oc get nodes --no-headers=true --selector='!node-role.kubernetes.io/master' | wc -l
4
```

I'm adding these additional logs to check what did happen.