### PR TITLE
Document OCPBUGS-13278

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -75,7 +75,8 @@
 # SR-IOV operator reports networks to be well-created,
 # but then it takes several minutes
 # to see them allocatable on the worker nodes.
-# We probably have to open a BZ.
+# OCPBUGS created in case of issues (OCP 4.12/13/14) - https://issues.redhat.com/browse/OCPBUGS-13278
+# Workaround included in check-resource common role in dci-openshift-agent for the moment
 - name: Ensure that SR-IOV networks are allocatable on the nodes
   block:
     - name: Wait to have all networks allocatable on worker nodes


### PR DESCRIPTION
There's a comment where it was said that a BZ was needed when having failures after having created SRIOV resources, and now this BZ is created.