### PR TITLE
Add support to IDMS

### DIFF
--- a/testpmd/hooks/mirror-catalog.yml
+++ b/testpmd/hooks/mirror-catalog.yml
@@ -7,6 +7,12 @@
     images:
       - "{{ example_cnf_index_image }}"
 
+- name: Find ImageDigestMirrorSet in the cluster
+  community.kubernetes.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: ImageDigestMirrorSet
+  register: idms_res
+
 - name: Mirror images in the catalog
   include_role:
     name: mirror-catalog
@@ -15,6 +21,7 @@
     mc_catalog: "{{ example_cnf_index_image }}"
     mc_registry: "{{ dci_local_registry }}"
     mc_pullsecret: "{{ pullsecret_tmp_file }}"
+    mc_is_type: "{{ idms_res.resources is defined and idms_res.resources | length | ternary('idms', 'icsp') }}"
   when:
     - dci_local_registry | length
     - pullsecret_tmp_file is defined

--- a/testpmd/hooks/mirror-catalog.yml
+++ b/testpmd/hooks/mirror-catalog.yml
@@ -19,53 +19,9 @@
     - dci_local_registry | length
     - pullsecret_tmp_file is defined
 
-# Workaround while oc_tool_path stable includes IDMS support
-# IDMS support is available in 4.14
-- name: Find ImageDigestMirrorSet in the cluster
-  community.kubernetes.k8s_info:
-    api_version: config.openshift.io/v1
-    kind: ImageDigestMirrorSet
-  register: idms_resources
-
-- name: Set image source kind
-  set_fact:
-    image_source_kind: >
-      {{ idms_resources.resources |
-         length |
-         ternary('ImageDigestMirrorSet', 'ImageContentSourcePolicy')
-      }}
-
-- name: Set Image Source file
-  set_fact:
-    example_cnf_is_file: "{{ mc_is_file.path }}"
-
-- name: Create temporary directory
-  tempfile:
-    state: directory
-    prefix: example-cnf
-  register: example_cnf_tmp_dir
-
-- name: Migrate ICSP to IDMS
-  when:
-    - image_source_kind == 'ImageDigestMirrorSet'
-    - "'imageContentSourcePolicy.yaml' in example_cnf_is_file"
-  block:
-    - name: Transform ICSP to IDMS
-      shell:
-        cmd: >
-          {{ oc_tool_path }} adm migrate icsp
-          {{ example_cnf_is_file }}
-          --dest-dir {{ example_cnf_tmp_dir.path }}
-      register: migrate_result
-
-    - name: Set new image source file
-      set_fact:
-        example_cnf_is_file: "{{ migrate_result.stdout_lines[0].split(' ')[-1] }}"
-# End of IDMS workaround
-
 - name: Apply Image Source file
   community.kubernetes.k8s:
-    src: "{{ example_cnf_is_file }}"
+    src: "{{ mc_is_file.path }}"
 
 - name: Wait for MCP status
   include_role:
@@ -82,8 +38,3 @@
     state: absent
   when: mc_is_file is defined
 
-- name: Delete example-cnf temporary directory
-  file:
-    path: "{{ example_cnf_tmp_dir.path }}"
-    state: absent
-  when: example_cnf_tmp_dir is defined

--- a/testpmd/hooks/mirror-catalog.yml
+++ b/testpmd/hooks/mirror-catalog.yml
@@ -19,9 +19,53 @@
     - dci_local_registry | length
     - pullsecret_tmp_file is defined
 
-- name: Apply ImageContentSourcePolicy
+# Workaround while oc_tool_path stable includes IDMS support
+# IDMS support is available in 4.14
+- name: Find ImageDigestMirrorSet in the cluster
+  community.kubernetes.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: ImageDigestMirrorSet
+  register: idms_resources
+
+- name: Set image source kind
+  set_fact:
+    image_source_kind: >
+      {{ idms_resources.resources |
+         length |
+         ternary('ImageDigestMirrorSet', 'ImageContentSourcePolicy')
+      }}
+
+- name: Set Image Source file
+  set_fact:
+    example_cnf_is_file: "{{ mc_is_file.path }}"
+
+- name: Create temporary directory
+  tempfile:
+    state: directory
+    prefix: example-cnf
+  register: example_cnf_tmp_dir
+
+- name: Migrate ICSP to IDMS
+  when:
+    - image_source_kind == 'ImageDigestMirrorSet'
+    - "'imageContentSourcePolicy.yaml' in example_cnf_is_file"
+  block:
+    - name: Transform ICSP to IDMS
+      shell:
+        cmd: >
+          {{ oc_tool_path }} adm migrate icsp
+          {{ example_cnf_is_file }}
+          --dest-dir {{ example_cnf_tmp_dir.path }}
+      register: migrate_result
+
+    - name: Set new image source file
+      set_fact:
+        example_cnf_is_file: "{{ migrate_result.stdout_lines[0].split(' ')[-1] }}"
+# End of IDMS workaround
+
+- name: Apply Image Source file
   community.kubernetes.k8s:
-    src: "{{ mc_icsp_file.path }}"
+    src: "{{ example_cnf_is_file }}"
 
 - name: Wait for MCP status
   include_role:
@@ -30,10 +74,16 @@
     resource_to_check: "MachineConfigPool"
     check_wait_retries: 60
     check_wait_delay: 60
-    check_reason: "ICSP update in mirror-rh-nfv"
+    check_reason: "Image Source update in mirror-rh-nfv"
 
-- name: Delete ImageContentSorucePolicy file
+- name: Delete Image Source file
   file:
-    path: "{{ mc_icsp_file.path }}"
+    path: "{{ mc_is_file.path }}"
     state: absent
-  when: mc_icsp_file is defined
+  when: mc_is_file is defined
+
+- name: Delete example-cnf temporary directory
+  file:
+    path: "{{ example_cnf_tmp_dir.path }}"
+    state: absent
+  when: example_cnf_tmp_dir is defined


### PR DESCRIPTION
IDMS or imageDigestMirrorSet deprecates ICSP or
imageContentSourcePolicies in OCP 4.14.
This adds support for the new resources as a workaround while the stable oc client that adds suport to this in the "adm catalog mirroring" is released.