### PR TITLE
Clean up example-cnf completely in teardown

### DIFF
--- a/testpmd/hooks/teardown.yml
+++ b/testpmd/hooks/teardown.yml
@@ -1,26 +1,58 @@
 ---
-- name: Delete TRexConfig CR
-  k8s:
+- name: "Get a list of Subscriptions in {{ cnf_namespace }} namespace"
+  community.kubernetes.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
     namespace: "{{ cnf_namespace }}"
-    kind: TRexConfig
-    name: "{{ trex_cr_name }}"
-    state: absent
+  register: sub_list
 
-- name: Delete TRexApp CR
-  k8s:
+- name: "Delete Subscriptions in {{ cnf_namespace }} namespace"
+  community.kubernetes.k8s:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
     namespace: "{{ cnf_namespace }}"
-    kind: TRexApp
-    name: "{{ trex_app_cr_name }}"
     state: absent
+    name: "{{ item.metadata.name }}"
+  with_items: "{{ sub_list.resources }}"
+  ignore_errors: yes
 
-- name: Check for deletion of TRex server pods
-  k8s_info:
+- name: "Get a list of ClusterServiceVersions in {{ cnf_namespace }} namespace"
+  community.kubernetes.k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
     namespace: "{{ cnf_namespace }}"
-    kind: Pod
-    label_selectors:
-      - example-cnf-type=pkt-gen
-  register: trex_result
-  retries: 30
-  delay: 5
-  until: "trex_result.resources|length == 0"
+  register: csv_list
+
+- name: "Delete ClusterServiceVersions in {{ cnf_namespace }} namespace"
+  community.kubernetes.k8s:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    namespace: "{{ cnf_namespace }}"
+    state: absent
+    name: "{{ item.metadata.name }}"
+  with_items: "{{ csv_list.resources }}"
+  ignore_errors: yes
+
+- name: "Delete all resources within the namespace {{ cnf_namespace }}"
+  shell: >
+    {{ oc_tool_path }} delete all --all -n {{ cnf_namespace }}
+  ignore_errors: yes
+
+- name: "Delete the namespace {{ cnf_namespace }}"
+  community.kubernetes.k8s:
+    name: "{{ cnf_namespace }}"
+    api_version: v1
+    kind: Namespace
+    state: absent
+  ignore_errors: yes
+
+- name: "Wait until namespace {{ cnf_namespace }} is deleted"
+  community.kubernetes.k8s_info:
+    api_version: v1
+    kind: Namespace
+    name: "{{ cnf_namespace }}"
+  register: stuck_namespace
+  until: stuck_namespace.resources | length == 0
+  retries: 6
+  delay: 10
 ...


### PR DESCRIPTION
This PR is to fix the issue seen by @manurodriguez while testing the 2-vlans setup. The idea is to rewrite the bash script I use for the cleanup in Ansible
```
# script 
$ cat cleanup-example-cnf.sh 
#!/bin/bash

# Define the namespace
NAMESPACE="example-cnf"

# Discover and delete Subscriptions
for sub in $(oc get sub -n $NAMESPACE -o custom-columns=NAME:.metadata.name --no-headers); do
    oc delete sub $sub -n $NAMESPACE
done

# Discover and delete ClusterServiceVersions
for csv in $(oc get csv -n $NAMESPACE -o custom-columns=NAME:.metadata.name --no-headers); do
    oc delete csv $csv -n $NAMESPACE
done

# Discover and delete all resources within the namespace
oc delete all --all -n $NAMESPACE

# Delete the namespace itself
oc delete ns $NAMESPACE

# execution
$ bash cleanup-example-cnf.sh 
subscription.operators.coreos.com "cnf-app-mac-operator" deleted
subscription.operators.coreos.com "testpmd-lb-operator" deleted
subscription.operators.coreos.com "testpmd-operator" deleted
subscription.operators.coreos.com "trex-operator" deleted
clusterserviceversion.operators.coreos.com "cnf-app-mac-operator.v0.2.10-202309181012.31a7dfb" deleted
clusterserviceversion.operators.coreos.com "elasticsearch-operator.v5.7.6" deleted
clusterserviceversion.operators.coreos.com "testpmd-lb-operator.v0.2.10-202309181012.31a7dfb" deleted
clusterserviceversion.operators.coreos.com "testpmd-operator.v0.2.10-202309181012.31a7dfb" deleted
clusterserviceversion.operators.coreos.com "trex-operator.v0.2.13-202309181012.31a7dfb" deleted
pod "cnf-app-mac-operator-controller-manager-6b956c8f5c-cbsng" deleted
pod "job-trex-app-7qhbh" deleted
pod "loadbalancer-6b7897f58c-2dcqm" deleted
pod "testpmd-app-6747bf475c-hqqr5" deleted
pod "testpmd-app-6747bf475c-wrppc" deleted
pod "testpmd-lb-operator-controller-manager-54f9684959-42dwx" deleted
pod "testpmd-operator-controller-manager-589f47d7fb-cnz6g" deleted
pod "trex-operator-controller-manager-86bbf6bd57-9hgdm" deleted
pod "trexconfig-84bdc6fb65-b9tqb" deleted
service "trex-server" deleted
deployment.apps "loadbalancer" deleted
deployment.apps "testpmd-app" deleted
deployment.apps "trexconfig" deleted
job.batch "job-trex-app" deleted
namespace "example-cnf" deleted
```