### PR TITLE
Rename roles from agents

### DIFF
--- a/testpmd/hooks/mirror-catalog.yml
+++ b/testpmd/hooks/mirror-catalog.yml
@@ -15,7 +15,7 @@
 
 - name: Mirror images in the catalog
   include_role:
-    name: mirror-catalog
+    name: mirror_catalog
   vars:
     mc_oc_tool_path: "{{ oc_tool_path }}"
     mc_catalog: "{{ example_cnf_index_image }}"
@@ -32,7 +32,7 @@
 
 - name: Wait for MCP status
   include_role:
-    name: check-resource
+    name: check_resource
   vars:
     resource_to_check: "MachineConfigPool"
     check_wait_retries: 60

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -175,7 +175,7 @@
 
     - name: Wait for MCP status
       include_role:
-        name: check-resource
+        name: check_resource
       vars:
         resource_to_check: "MachineConfigPool"
         check_wait_retries: 60

--- a/testpmd/hooks/tests.yml
+++ b/testpmd/hooks/tests.yml
@@ -7,7 +7,7 @@
 
 - name: Checking found CalalogSource with opcap
   include_role:
-    name: opcap-tool
+    name: opcap_tool
   vars:
     opcap_target_catalog_source: "nfv-example-cnf-catalog"
     opcap_catalog_source_namespace: "openshift-marketplace"


### PR DESCRIPTION
Agents have renamed their roles to use underscores instead of hyphens.

build-depends: 29660