### PR TITLE
Use collections for roles

### DIFF
--- a/testpmd/hooks/mirror-catalog.yml
+++ b/testpmd/hooks/mirror-catalog.yml
@@ -1,7 +1,7 @@
 ---
 - name: Mirror catalog image
   include_role:
-    name: mirror_images
+    name: redhatci.ocp.mirror_images
   vars:
     authfile: "{{ pullsecret_tmp_file }}"
     images:
@@ -15,7 +15,7 @@
 
 - name: Mirror images in the catalog
   include_role:
-    name: mirror_catalog
+    name: redhatci.ocp.mirror_catalog
   vars:
     mc_oc_tool_path: "{{ oc_tool_path }}"
     mc_catalog: "{{ example_cnf_index_image }}"
@@ -32,7 +32,7 @@
 
 - name: Wait for MCP status
   include_role:
-    name: check_resource
+    name: redhatci.ocp.check_resource
   vars:
     resource_to_check: "MachineConfigPool"
     check_wait_retries: 60

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -175,7 +175,7 @@
 
     - name: Wait for MCP status
       include_role:
-        name: check_resource
+        name: redhatci.ocp.check_resource
       vars:
         resource_to_check: "MachineConfigPool"
         check_wait_retries: 60

--- a/testpmd/hooks/tests.yml
+++ b/testpmd/hooks/tests.yml
@@ -7,7 +7,7 @@
 
 - name: Checking found CalalogSource with opcap
   include_role:
-    name: opcap_tool
+    name: redhatci.ocp.opcap_tool
   vars:
     opcap_target_catalog_source: "nfv-example-cnf-catalog"
     opcap_catalog_source_namespace: "openshift-marketplace"


### PR DESCRIPTION
Roles have been migrated to collections and need FQCN to use them

Build-depends: 29637
Build-depends: 29638
Build-depends: https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/7