### PR TITLE
Make sure cnf_namespace is defined when running the teardown

### DIFF
--- a/testpmd/hooks/teardown.yml
+++ b/testpmd/hooks/teardown.yml
@@ -1,4 +1,10 @@
 ---
+- name: Check that cnf_namespace is defined
+  assert:
+    that:
+      - cnf_namespace is defined
+    fail_msg: "Please make sure cnf_namespace variable is defined to run the teardown"
+
 - name: "Get a list of Subscriptions in {{ cnf_namespace }} namespace"
   community.kubernetes.k8s_info:
     api_version: operators.coreos.com/v1alpha1


### PR DESCRIPTION
If we just launch the example-cnf teardown, currently it's not working because cnf_namespace variable is not defined. We need to define it in the teardown stage too.

Example: https://www.distributed-ci.io/jobs/11550c7b-9fc4-42d8-9ad2-4578e50c0a07/jobStates?sort=date&task=fd1d9a37-2d51-412f-b2b1-bc8c386ecee6