### PR TITLE
Ensure the teardown of all related resources created

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -139,7 +139,7 @@
 #      - "0000:d8:00.0"
 #    nodeselector: '"node.openshift.io/nic_type": "intel810"'
 - name: Create SriovNetworkNodePolicy
-  k8s:
+  community.kubernetes.k8s:
     definition: "{{ lookup('template', 'templates/sriov-policy.yml.j2') }}"
   loop: "{{ sriov_network }}"
   loop_control:
@@ -148,7 +148,7 @@
   tags: [sriov]
 
 - name: Create SriovNetwork
-  k8s:
+  community.kubernetes.k8s:
     definition: "{{ lookup('template', 'templates/sriov-network.yml.j2') }}"
   loop: "{{ sriov_network }}"
   loop_control:

--- a/testpmd/hooks/teardown.yml
+++ b/testpmd/hooks/teardown.yml
@@ -1,4 +1,5 @@
 ---
+# Delete resources deployed under example-cnf namespace
 - name: Check that cnf_namespace is defined
   assert:
     that:
@@ -61,4 +62,41 @@
   until: stuck_namespace.resources | length == 0
   retries: 6
   delay: 10
+
+# Delete example-cnf CatalogSource
+- name: Delete example-cnf CatalogSource
+  community.kubernetes.k8s:
+    api_version: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    name: "{{ catalog_name | default('nfv-example-cnf-catalog') }}"
+    namespace: openshift-marketplace
+    state: absent
+
+# Delete SRIOV resources
+- name: Delete SriovNetwork
+  community.kubernetes.k8s:
+    api_version: sriovnetwork.openshift.io/v1
+    kind: SriovNetwork
+    name: "{{ sriov['name'] }}"
+    namespace: openshift-sriov-network-operator
+    state: absent
+  loop: "{{ sriov_network }}"
+  loop_control:
+    loop_var: sriov
+  when: sriov_network is defined
+  tags: [sriov]
+
+- name: Delete SriovNetworkNodePolicy
+  community.kubernetes.k8s:
+    api_version: sriovnetwork.openshift.io/v1
+    kind: SriovNetworkNodePolicy
+    name: "{{ sriov['policy'] }}"
+    namespace: openshift-sriov-network-operator
+    state: absent
+  loop: "{{ sriov_network }}"
+  loop_control:
+    loop_var: sriov
+  when: sriov_network is defined
+  tags: [sriov]
+
 ...


### PR DESCRIPTION
Currently, the teardown is just cleaning the example-cnf namespace and the resources created there, but there are some other resources, e.g. CatalogSource, SRIOV resources, etc. that are not deleted and they should, for a correct teardown.