### PR TITLE
Fix recursion on Get pods from example-cnf namespace

### DIFF
--- a/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Get pods from example-cnf namespace
   community.kubernetes.k8s_info:
     api_version: v1
-    kind: pod
+    kind: Pod
     namespace: "{{ app_ns }}"
   register: example_cnf_pod_list
 


### PR DESCRIPTION
This is to avoid issues like this one, seen on daily jobs: https://www.distributed-ci.io/jobs/ace02bf4-eab0-48b6-a1a2-64380a28d671/jobStates?sort=date&task=b22d21cc-32e8-4a75-923f-d1a746bd73ea

The problem happened in other hooks too: Pod must be upper case, not lower case.