### PR TITLE
Remove MAC workaround

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -8,7 +8,6 @@
     packet_generator_networks:
       - name: intel-numa0-net2
         count: 2
-    mac_workaround_enable: false
     cnf_namespace: "example-cnf"
 
 - name: Get example-cnf component details from job.components


### PR DESCRIPTION
build-depends: https://github.com/rh-nfv-int/nfv-example-cnf-deploy/pull/46
build-depends: https://github.com/openshift-kni/example-cnf/pull/42

This is no longer used since it was just required for OCP 4.5, which is EOL.