### PR TITLE
Add namespace resource quota

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -115,6 +115,11 @@
   set_fact:
     ns_list: "{{ ns_list|default([]) + [ cnf_namespace ] }}"
 
+- name: Create ResourceQuotas for namespace
+  community.kubernetes.k8s:
+    state: present
+    definition: "{{ lookup('template', 'templates/resource_quota.yml.j2') | from_yaml }}"
+
 - name: Create SRIOV Policies and networks
   ansible.builtin.include_role:
     name: redhatci.ocp.sriov_config

--- a/testpmd/hooks/templates/resource_quota.yml.j2
+++ b/testpmd/hooks/templates/resource_quota.yml.j2
@@ -8,7 +8,7 @@ items:
       namespace: {{ cnf_namespace }}
     spec:
       hard:
-        cpu: "1000"
+        cpu: "100"
         memory: 200Gi
         pods: "10"
       scopeSelector:

--- a/testpmd/hooks/templates/resource_quota.yml.j2
+++ b/testpmd/hooks/templates/resource_quota.yml.j2
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: ResourceQuota
+    metadata:
+      name: pods-high
+      namespace: {{ cnf_namespace }}
+    spec:
+      hard:
+        cpu: "1000"
+        memory: 200Gi
+        pods: "10"
+      scopeSelector:
+        matchExpressions:
+          - operator: In
+            scopeName: PriorityClass
+            values: ["high"]
+  - apiVersion: v1
+    kind: ResourceQuota
+    metadata:
+      name: pods-medium
+      namespace: {{ cnf_namespace }}
+    spec:
+      hard:
+        cpu: "10"
+        memory: 20Gi
+        pods: "10"
+      scopeSelector:
+        matchExpressions:
+          - operator: In
+            scopeName: PriorityClass
+            values: ["medium"]
+  - apiVersion: v1
+    kind: ResourceQuota
+    metadata:
+      name: pods-low
+      namespace: {{ cnf_namespace }}
+    spec:
+      hard:
+        cpu: "5"
+        memory: 10Gi
+        pods: "10"
+      scopeSelector:
+        matchExpressions:
+          - operator: In
+            scopeName: PriorityClass
+            values: ["low"]


### PR DESCRIPTION
This targets this tnf test:

- access-control-namespace-resource-quota: namespaces under test require a resource quota.

Just applying the same we're using in tnf_test_example, for simplicity: https://github.com/redhat-cip/dci-openshift-app-agent/blob/master/samples/tnf_test_example/hooks/templates/resource_quota.yml.j2