### PR TITLE
Use opm binary downloaded from dci-openshift-app-agent

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -73,7 +73,7 @@
       ansible.builtin.shell:
         cmd: >
           set -e -o pipefail;
-          ~/clusterconfigs-{{ cluster_name }}/opm render
+          {{ opm_tool_path }} render
           {{ example_cnf_index_image }} |
           jq -r '.relatedImages[].image'
       args:


### PR DESCRIPTION
This is to avoid the issue with opm binary found yesterday and that is causing CILAB-1108 today in daily jobs. We should use the opm binary that is downloaded by dci-openshift-app-agent

build-depends: https://github.com/rh-nfv-int/nfv-example-cnf-deploy/pull/50