### PR TITLE
Update cnf_app_networks and packet_generator_networks to use multiple SRIOV nets

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -4,10 +4,14 @@
   set_fact:
     cnf_app_networks:
       - name: intel-numa0-net1
-        count: 2
-    packet_generator_networks:
+        count: 1
       - name: intel-numa0-net2
-        count: 2
+        count: 1
+    packet_generator_networks:
+      - name: intel-numa0-net3
+        count: 1
+      - name: intel-numa0-net4
+        count: 1
     cnf_namespace: "example-cnf"
 
 - name: Get example-cnf component details from job.components


### PR DESCRIPTION
build-depends: https://github.com/rh-nfv-int/nfv-example-cnf-deploy/pull/52
build-depends: https://github.com/dci-labs/dallas-config/pull/125
build-depends: https://github.com/openshift-kni/example-cnf/pull/62