### PR TITLE
Revert "Merge pull request #97 from dci-labs/update-sriov-networks"

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -4,14 +4,10 @@
   set_fact:
     cnf_app_networks:
       - name: intel-numa0-net1
-        count: 1
-      - name: intel-numa0-net2
-        count: 1
+        count: 2
     packet_generator_networks:
-      - name: intel-numa0-net3
-        count: 1
-      - name: intel-numa0-net4
-        count: 1
+      - name: intel-numa0-net2
+        count: 2
     cnf_namespace: "example-cnf"
 
 - name: Get example-cnf component details from job.components


### PR DESCRIPTION
build-depends: https://github.com/dci-labs/dallas-config/pull/128

This reverts commit 9b09d9ea56fedb427648672318e4c9734ccdc75b, reversing changes made to 165b78f01f59e062fd8d5c5c6bd9288c24d8654b.

I'm going to check what happens if I return to the previous SRIOV setup, but using the new example-cnf code that binds MAC-PCI addresses. Let's see if this makes it work and CILAB-291 disappears