### PR TITLE
Debug feature - Use example_cnf_skip_trex_job_failure to define trex_tests_skip_failures var to avoid failing if TRex fails

### DIFF
--- a/testpmd/README.md
+++ b/testpmd/README.md
@@ -1,0 +1,9 @@
+# Testpmd
+
+This hook interacts with [nfv-example-cnf-deploy](https://github.com/rh-nfv-int/nfv-example-cnf-deploy) repository to deploy all resources from example-cnf scenario, then launch TRex job to evaluate the packet loss ratio in the deployment made.
+
+Some variables than can be used for debugging purposes:
+
+| Name                              | Required | Default    | Description                                    |
+|-----------------------------------|----------|------------|------------------------------------------------|
+| example_cnf_skip_trex_job_failure | No       | false      | If true, do not fail the job if TRex job fails |

--- a/testpmd/hooks/install.yml
+++ b/testpmd/hooks/install.yml
@@ -4,6 +4,10 @@
   include_role:
     name: "{{ deploy_dir }}/roles/example-cnf-app"
 
+- name: Retrieve output from example-cnf-app role
+  set_fact:
+    trex_app_passed: "{{ trex_app_run_passed | default(false) | bool}}"
+
 # if replica = 1, recommended not to set maxUnavailable to 0 or 0% and minAvailable to 100% for upgrades
 # https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/adding-pod-disruption-budgets.md#limitations-on-pod-disruption-budgets
 # TODO (in a new patch): update PDB during upgrades to avoid issues during node draining, something like:

--- a/testpmd/hooks/install.yml
+++ b/testpmd/hooks/install.yml
@@ -1,12 +1,10 @@
 ---
 
 - name: Deploy the Example CNF applications
+  vars:
+    trex_tests_skip_failures: "{{ example_cnf_skip_trex_job_failure | default(false) | bool }}"
   include_role:
     name: "{{ deploy_dir }}/roles/example-cnf-app"
-
-- name: Retrieve output from example-cnf-app role
-  set_fact:
-    trex_app_passed: "{{ trex_app_run_passed | default(false) | bool}}"
 
 # if replica = 1, recommended not to set maxUnavailable to 0 or 0% and minAvailable to 100% for upgrades
 # https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/adding-pod-disruption-budgets.md#limitations-on-pod-disruption-budgets

--- a/testpmd/hooks/tests.yml
+++ b/testpmd/hooks/tests.yml
@@ -1,9 +1,11 @@
 ---
+# Migration test cannot be run if the TRex app job did not pass
 - name: Run migration test
   include_role:
     name: "{{ deploy_dir }}/roles/example-cnf-validate"
   when:
     - run_migration_test|default(true)|bool
+    - trex_app_passed|default(false)|bool
 
 - name: Checking found CalalogSource with opcap
   include_role:

--- a/testpmd/hooks/tests.yml
+++ b/testpmd/hooks/tests.yml
@@ -1,11 +1,11 @@
 ---
-# Migration test cannot be run if the TRex app job did not pass
 - name: Run migration test
+  vars:
+    trex_tests_skip_failures: "{{ example_cnf_skip_trex_job_failure | default(false) | bool }}"
   include_role:
     name: "{{ deploy_dir }}/roles/example-cnf-validate"
   when:
     - run_migration_test|default(true)|bool
-    - trex_app_passed|default(false)|bool
 
 - name: Checking found CalalogSource with opcap
   include_role:


### PR DESCRIPTION
depends-on: https://github.com/rh-nfv-int/nfv-example-cnf-deploy/pull/58