### PR TITLE
Add retries with SriovNetworkNodePolicy deletion

### DIFF
--- a/testpmd/hooks/teardown.yml
+++ b/testpmd/hooks/teardown.yml
@@ -100,5 +100,9 @@
   loop_control:
     loop_var: sriov_node_policy
   tags: [sriov]
+  retries: 6
+  delay: 10
+  register: node_policy_retry
+  until: node_policy_retry.error is not defined
 
 ...


### PR DESCRIPTION
Doing the same than with [SriovNetworkNodePolicy creation](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/sriov_config/tasks/create_node_policies.yml#L11-L15), after finding a [case](https://www.distributed-ci.io/jobs/1a16673c-0d1a-40a3-a66a-5f33225750e9/jobStates?sort=date&task=650463f3-7f10-47da-82b6-57f8c7534b48) where this task was failing with the same look and feel than SRIOV creation before including the workaround of repeating the task.