### PR TITLE
Change hooks tasks to adapt to new certsuite role

### DIFF
--- a/testpmd/hooks/install.yml
+++ b/testpmd/hooks/install.yml
@@ -29,9 +29,9 @@
     state: present
     definition: "{{ lookup('template', 'templates/pdb.yml.j2') | from_yaml }}"
 
-- name: Apply configuration for CNF Cert Suite execution
+- name: Apply configuration for certsuite execution
   include_role:
-    name: "{{ dci_config_dir }}/hooks/roles/apply-cnf-cert-config"
-  when: do_cnf_cert|default(false)|bool
+    name: "{{ dci_config_dir }}/hooks/roles/apply-certsuite-config"
+  when: do_certsuite|default(false)|bool
 
 ...

--- a/testpmd/hooks/roles/apply-certsuite-config/defaults/main.yml
+++ b/testpmd/hooks/roles/apply-certsuite-config/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# app_ns could also be: "{{ kbpc_test_config[0].namespace|default('example-cnf') }}"
+app_ns: "{{ cnf_namespace }}"
+exclude_connectivity_regexp: "{{ kbpc_test_config[0].exclude_connectivity_regexp|default('loadbalancer|testpmd-app') }}"
+
+...

--- a/testpmd/hooks/roles/apply-certsuite-config/tasks/main.yml
+++ b/testpmd/hooks/roles/apply-certsuite-config/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 # Label pods - only the labels related to exclude connectivity features are applied, as the
-# pods are autodiscovered based on the labels provided in tnf_targetpodlabels variable
+# pods are autodiscovered based on the labels provided in targetpodlabels variable
 # in the pipeline
 
 - name: Get pods from example-cnf namespace

--- a/testpmd/hooks/roles/apply-cnf-cert-config/defaults/main.yml
+++ b/testpmd/hooks/roles/apply-cnf-cert-config/defaults/main.yml
@@ -1,6 +1,0 @@
----
-# app_ns could also be: "{{ tnf_config[0].namespace|default('example-cnf') }}"
-app_ns: "{{ cnf_namespace }}"
-exclude_connectivity_regexp: "{{ tnf_config[0].exclude_connectivity_regexp|default('loadbalancer|testpmd-app') }}"
-
-...


### PR DESCRIPTION
- Move cnf_cert role logic to new k8s_best_practices_certsuite, to follow the new naming convention of the cnf-certification-test project