### PR TITLE
Ignore errors if DCI component deletion is failing when testing a PR

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -48,11 +48,14 @@
             operator_version: "{{ index_output.stdout }}"
             example_cnf_index_image: "quay.io/rh-nfv-int/nfv-example-cnf-catalog:{{ index_output.stdout }}"
 
-        - name: 'Remove  component from the job'
+        # If running a test from BOS2, as the component belongs to telco-ci-partner team and not to DCI team,
+        # this task would fail because the component owner is a different one. Using ignore_errors for that case.
+        - name: 'Remove component from the job'
           dci_job_component:
             component_id: "{{ operator_component_id }}"
             job_id: " {{ job_id }} "
             state: absent
+          ignore_errors: true
 
       when: examplecnf_change_dir.stat.exists and examplecnf_change_dir.stat.isdir
   when:


### PR DESCRIPTION
If running a test from BOS2, as the component belongs to telco-ci-partner team and not to DCI team, this task would fail because the component owner is a different one. Using ignore_errors for that case.