### PR TITLE
Rename SRIOV config in example-cnf to avoid using numa references

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -3,14 +3,14 @@
 - name: Create example-cnf facts
   set_fact:
     ecd_cnf_app_networks:
-      - name: intel-numa0-net1
+      - name: example-cnf-net1
         count: 1
-      - name: intel-numa0-net2
+      - name: example-cnf-net2
         count: 1
     ecd_packet_generator_networks:
-      - name: intel-numa0-net3
+      - name: example-cnf-net3
         count: 1
-      - name: intel-numa0-net4
+      - name: example-cnf-net4
         count: 1
     ecd_cnf_namespace: "example-cnf"
 


### PR DESCRIPTION
- Generalize the example-cnf SRIOV policy and network names and avoid using references to specific technologies (intel) and nodes (numa0), since this may be different in other deployments (e.g. BOS2) and may confuse people