### PR TITLE
Remove references to testpmd-lb-operator

### DIFF
--- a/draining_validation/README.md
+++ b/draining_validation/README.md
@@ -5,6 +5,5 @@ If example-cnf is launched in continuous mode (or emulating continuous mode with
 For this to work, some requirements need to be met:
 
 - example-cnf needs to be deployed in continuous mode or emulating continuous mode, as said before.
-- Direct mode needs to be used, this is not currently validated against loadbalancing mode.
 - The MAC addresses used by testpmd pod need to be hardcoded, to ensure the same MAC addresses are used in the new pod scheduled in a different worker node.
 - There must be 3+ worker nodes to allow testpmd being reallocated in a different worker, also different than the worker node where trex is running.

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -2,15 +2,10 @@
 
 - name: Create example-cnf facts
   set_fact:
-    ecd_cnf_app_networks:
+    ecd_sriov_networks:
       - name: example-cnf-net1
         count: 1
       - name: example-cnf-net2
-        count: 1
-    ecd_packet_generator_networks:
-      - name: example-cnf-net3
-        count: 1
-      - name: example-cnf-net4
         count: 1
     ecd_cnf_namespace: "example-cnf"
 
@@ -117,7 +112,6 @@
     state: present
     definition: "{{ lookup('template', 'templates/network_policies_cnf_traffic.yml.j2') | from_yaml }}"
   loop:
-    - "example-cnf-type=lb-app"
     - "example-cnf-type=cnf-app"
     - "example-cnf-type=pkt-gen"
     - "example-cnf-type=pkt-gen-app"

--- a/testpmd/hooks/roles/apply-certsuite-config/defaults/main.yml
+++ b/testpmd/hooks/roles/apply-certsuite-config/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # app_ns could also be: "{{ kbpc_test_config[0].namespace|default('example-cnf') }}"
 app_ns: "{{ ecd_cnf_namespace }}"
-exclude_connectivity_regexp: "{{ kbpc_test_config[0].exclude_connectivity_regexp|default('loadbalancer|testpmd-app') }}"
+exclude_connectivity_regexp: "{{ kbpc_test_config[0].exclude_connectivity_regexp|default('testpmd-app') }}"
 
 ...


### PR DESCRIPTION
example-cnf's testpmd-lb-operator is deprecated and we're removing it from the repo, so removing all code related to deploying it.

