### PR TITLE
Remove ignore_errors when trying to remove nfv-example-cnf-index component

### DIFF
--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -43,14 +43,11 @@
             operator_version: "{{ index_output.stdout }}"
             example_cnf_index_image: "quay.io/rh-nfv-int/nfv-example-cnf-catalog:{{ index_output.stdout }}"
 
-        # If running a test from BOS2, as the component belongs to telco-ci-partner team and not to DCI team,
-        # this task would fail because the component owner is a different one. Using ignore_errors for that case.
         - name: 'Remove component from the job'
           dci_job_component:
             component_id: "{{ operator_component_id }}"
             job_id: " {{ job_id }} "
             state: absent
-          ignore_errors: true
 
       when: examplecnf_change_dir.stat.exists and examplecnf_change_dir.stat.isdir
   when:


### PR DESCRIPTION
In theory, the previous issue we had was fixed with https://softwarefactory-project.io/r/c/dci-control-server/+/32710, so we can remove the `ignore_errors` here

build-depends: https://github.com/openshift-kni/example-cnf/pull/106

- [x] Validation on example-cnf - https://www.distributed-ci.io/jobs/296f4a79-b55d-4ffd-97a7-2d79eab66f85/jobStates?sort=date&task=fdd4cf29-3c61-4251-8e6f-03caa758bb25