### PR TITLE
Switch to kubernetes.core collection

### DIFF
--- a/launch_trex_job/hooks/install.yml
+++ b/launch_trex_job/hooks/install.yml
@@ -1,6 +1,6 @@
 ---
 - name: Select event from the default TRex profile
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: Event
     namespace: "{{ ecd_cnf_namespace }}"
@@ -9,7 +9,7 @@
   register: default_events
 
 - name: Remove events from the default TRex profile
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     api_version: v1
     kind: Event
     state: absent

--- a/testpmd/hooks/install.yml
+++ b/testpmd/hooks/install.yml
@@ -1,6 +1,6 @@
 ---
 - name: Get all RuntimeClass
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: node.k8s.io/v1
     kind: RuntimeClass
   register: rclass
@@ -29,7 +29,7 @@
 # TODO (in a new patch): update PDB during upgrades to avoid issues during node draining, something like:
 # https://medium.com/@tamber/solution-avoid-kubernetes-openshift-node-drain-failure-due-to-active-poddisruptionbudget-df68efed2c4f
 - name: Create PodDisruptionBudget for controller-manager pods
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'templates/pdb.yml.j2') | from_yaml }}"
 

--- a/testpmd/hooks/mirror-catalog.yml
+++ b/testpmd/hooks/mirror-catalog.yml
@@ -9,7 +9,7 @@
     mi_registry: "{{ dci_local_registry }}"
 
 - name: Find ImageDigestMirrorSet in the cluster
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: config.openshift.io/v1
     kind: ImageDigestMirrorSet
   register: idms_res
@@ -28,7 +28,7 @@
     - pullsecret_tmp_file is defined
 
 - name: Apply Image Source file
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     src: "{{ mc_is_file.path }}"
 
 - name: Wait for MCP status

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -88,7 +88,7 @@
         msg: "{{ preflight_operators_to_certify }}"
 
 - name: "Create CNF Namespace"
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     state: present
     definition:
       apiVersion: v1
@@ -105,7 +105,7 @@
     ns_list: "{{ ns_list|default([]) + [ ecd_cnf_namespace ] }}"
 
 - name: Set the CNF mandatory network policies
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'templates/network_policies_cnf_traffic.yml.j2') | from_yaml }}"
   loop:
@@ -117,12 +117,12 @@
     loop_var: label
 
 - name: Set network policies for openshift DNS, API and Istio
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'templates/network_policies_istio_dns_api_traffic.yml.j2') | from_yaml }}"
 
 - name: Create ResourceQuotas for namespace
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'templates/resource_quota.yml.j2') | from_yaml }}"
 

--- a/testpmd/hooks/roles/apply-certsuite-config/tasks/main.yml
+++ b/testpmd/hooks/roles/apply-certsuite-config/tasks/main.yml
@@ -5,7 +5,7 @@
 # in the pipeline
 
 - name: Get pods from example-cnf namespace
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: Pod
     namespace: "{{ app_ns }}"
@@ -15,7 +15,7 @@
 # "It's highly recommended that the labels should be defined in pod definition rather 
 # than added after pod is created"
 - name: "Tag pods with autodiscovery labels related to exclude connectivity features in test suites"
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     definition:
       apiVersion: v1
       kind: Pod

--- a/testpmd/hooks/teardown.yml
+++ b/testpmd/hooks/teardown.yml
@@ -7,14 +7,14 @@
     fail_msg: "Please make sure ecd_cnf_namespace variable is defined to run the teardown"
 
 - name: "Get a list of Subscriptions in {{ ecd_cnf_namespace }} namespace"
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
     namespace: "{{ ecd_cnf_namespace }}"
   register: sub_list
 
 - name: "Delete Subscriptions in {{ ecd_cnf_namespace }} namespace"
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
     namespace: "{{ ecd_cnf_namespace }}"
@@ -24,14 +24,14 @@
   ignore_errors: yes
 
 - name: "Get a list of ClusterServiceVersions in {{ ecd_cnf_namespace }} namespace"
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: ClusterServiceVersion
     namespace: "{{ ecd_cnf_namespace }}"
   register: csv_list
 
 - name: "Delete ClusterServiceVersions in {{ ecd_cnf_namespace }} namespace"
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     api_version: operators.coreos.com/v1alpha1
     kind: ClusterServiceVersion
     namespace: "{{ ecd_cnf_namespace }}"
@@ -46,7 +46,7 @@
   ignore_errors: yes
 
 - name: "Delete the namespace {{ ecd_cnf_namespace }}"
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     name: "{{ ecd_cnf_namespace }}"
     api_version: v1
     kind: Namespace
@@ -54,7 +54,7 @@
   ignore_errors: yes
 
 - name: "Wait until namespace {{ ecd_cnf_namespace }} is deleted"
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: Namespace
     name: "{{ ecd_cnf_namespace }}"
@@ -65,7 +65,7 @@
 
 # Delete example-cnf CatalogSource
 - name: Delete example-cnf CatalogSource
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     api_version: operators.coreos.com/v1alpha1
     kind: CatalogSource
     name: "{{ ecd_catalog_name | default('nfv-example-cnf-catalog') }}"
@@ -78,7 +78,7 @@
     file: "{{ example_cnf_sriov_file }}"
 
 - name: Delete SriovNetwork
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     api_version: sriovnetwork.openshift.io/v1
     kind: SriovNetwork
     name: "{{ sriov_network.name }}"
@@ -90,7 +90,7 @@
   tags: [sriov]
 
 - name: Delete SriovNetworkNodePolicy
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     api_version: sriovnetwork.openshift.io/v1
     kind: SriovNetworkNodePolicy
     name: "{{ sriov_node_policy.name }}"

--- a/upgrade_validation/hooks/install.yml
+++ b/upgrade_validation/hooks/install.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Select event from the default T-REX Profile"
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: Event
     namespace: "{{ ecd_cnf_namespace }}"
@@ -9,7 +9,7 @@
   register: default_events
 
 - name: "Remove events from the default T-REX Profile"
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     api_version: v1
     kind: Event
     state: absent
@@ -32,7 +32,7 @@
     name: redhatci.ocp.example_cnf_deploy
 
 - name: "run k8s info on jobs"
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     kind: Job
     namespace: "{{ ecd_cnf_namespace }}"
   register: job
@@ -44,7 +44,7 @@
       list: "{{ job | json_query('resources[*].metadata.name')}}"
 
 - name: "Retrieve logs from jobs"
-  community.kubernetes.k8s_log:
+  kubernetes.core.k8s_log:
     namespace: "{{ ecd_cnf_namespace }}"
     label_selectors:
       - job-name={{ job_name }}


### PR DESCRIPTION
The community.kubernetes collection has been deprecated by kubernetes.core and the agent is ready to use it.