### PR TITLE
update jq cmd to skip iteration over null

### DIFF
--- a/launch_trex_job/hooks/pre-run.yml
+++ b/launch_trex_job/hooks/pre-run.yml
@@ -18,7 +18,7 @@
       set -e -o pipefail;
       {{ opm_tool_path }} render
       {{ catalog_image }} |
-      jq -r '.relatedImages[].image'
+      jq -rn 'inputs | select(.schema == "olm.bundle").relatedImages[].image'
   args:
     executable: /bin/bash
   register: catalog_data_cmd

--- a/testpmd/hooks/pre-run.yml
+++ b/testpmd/hooks/pre-run.yml
@@ -64,7 +64,7 @@
           set -e -o pipefail;
           {{ opm_tool_path }} render
           {{ example_cnf_index_image }} |
-          jq -r '.relatedImages[].image'
+          jq -rn 'inputs | select(.schema == "olm.bundle").relatedImages[].image'
       args:
         executable: /bin/bash
       register: catalog_data_cmd


### PR DESCRIPTION
#####SUMMARY
Update jq command to skip iteration over null, to prevent "jq: error Cannot iterate over null" 

#####ISSUE TYPE
Nominal change

build-depends: https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/616

#####Tests

- [ ] TestDallas: ocp-4.16-vanilla example-cnf
https://www.distributed-ci.io/jobs/040c3eb2-dd05-4a36-956b-35198e423dc0/jobStates
