### PR TITLE
Execute dci_* tasks from localhost

### DIFF
--- a/cnfapp/hooks/pre-run.yml
+++ b/cnfapp/hooks/pre-run.yml
@@ -57,7 +57,7 @@
             component_id: "{{ operator_component_id }}"
             job_id: " {{ job_id }} "
             state: absent
-
+          delegate_to: localhost
       when: examplecnf_change_dir.stat.exists and examplecnf_change_dir.stat.isdir
   when:
     - dci_change_dir is defined


### PR DESCRIPTION
Found while testing in Dallas with https://github.com/dci-labs/dallas-pipelines/pull/1409. We need to run DCI-related tasks in jumphost, else we'll have credential issues.

- [x] Dallas job - https://www.distributed-ci.io/jobs/898b3759-247d-4e1c-9eca-a3b97ea63cf7/jobStates/?sort=date
- [x] BOS2 job - https://www.distributed-ci.io/jobs/06a5e158-04ab-4ea0-94bd-cd6ed1f433d4/jobStates?sort=date

Test-Hints: no-check