### PR TITLE
Create SriovNetworkPoolConfig to enable RDMA exclusive mode

### DIFF
--- a/cnfapp/README.md
+++ b/cnfapp/README.md
@@ -8,8 +8,9 @@ Some variables than can be used for debugging purposes:
 
 | Name                              | Required | Default    | Description                                                                                           |
 |-----------------------------------|----------|------------|-------------------------------------------------------------------------------------------------------|
+| example_cnf_enable_rdma_exclusive | No       | false      | Enable RDMA exclusive mode to configure a RDMA subsystem for SRIOV. This requires a specific setup for the SriovNetwork, please check [this documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/networking/hardware-networks#nw-sriov-networknodepolicy-object_configuring-sriov-device). This procedure only applies to Mellanox NICs. |
 | example_cnf_cnfapp_name           | No       | grout      | CNFApp to be used. Could be "grout" or "testpmd"                                                      |
 | example_cnf_skip_trex_job_failure | No       | false      | If true, do not fail the job if TRex job fails                                                        |
 | example_cnf_network_config_file   | No       | ''         | Path to find the network config file to provide IP-MAC config to TRex and CNFApp (required for Grout) |
-| run_migration_test                | No       | true       | Enable migration tests |
-| run_opcap_check                   | No       | true       | Enable opcap check |
+| run_migration_test                | No       | true       | Enable migration tests                                                                                |
+| run_opcap_check                   | No       | true       | Enable opcap check                                                                                    |

--- a/cnfapp/hooks/pre-run.yml
+++ b/cnfapp/hooks/pre-run.yml
@@ -135,11 +135,30 @@
     state: present
     definition: "{{ lookup('template', 'templates/resource_quota.yml.j2') | from_yaml }}"
 
+- name: Create SriovNetworkPoolConfig to enable RDMA exclusive mode
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: sriovnetwork.openshift.io/v1
+      kind: SriovNetworkPoolConfig
+      metadata:
+        name: worker
+        namespace: openshift-sriov-network-operator
+      spec:
+        maxUnavailable: 1
+        nodeSelector:
+          matchLabels:
+            node-role.kubernetes.io/worker: ""
+        rdmaMode: exclusive
+  tags: [sriov]
+  when: example_cnf_enable_rdma_exclusive | default(false) | bool
+
 - name: Create SRIOV Policies and networks
-  ansible.builtin.include_role:
-    name: redhatci.ocp.sriov_config
   vars:
     sriov_config_file: "{{ example_cnf_sriov_file }}"
+  ansible.builtin.include_role:
+    name: redhatci.ocp.sriov_config
+  tags: [sriov]
 
 - name: "Install required rpm packages"
   package:

--- a/cnfapp/hooks/teardown.yml
+++ b/cnfapp/hooks/teardown.yml
@@ -105,4 +105,14 @@
   register: node_policy_retry
   until: node_policy_retry.error is not defined
 
+- name: Delete SriovNetworkPoolConfig
+  kubernetes.core.k8s:
+    api_version: sriovnetwork.openshift.io/v1
+    kind: SriovNetworkPoolConfig
+    name: worker
+    namespace: openshift-sriov-network-operator
+    state: absent
+  tags: [sriov]
+  when: example_cnf_enable_rdma_exclusive | default(false) | bool
+
 ...


### PR DESCRIPTION
- Create (and delete in the teardown stage) SriovNetworkPoolConfig to enable a RDMA subsystem for SRIOV
- This only applies when using Mellanox cards

- [x] Deployment with this setup already configured - https://www.distributed-ci.io/jobs/69325e32-56e6-4eb8-9a5d-3faee1485df4/jobStates

```
$ oc get sriovnetworkpoolconfig -n openshift-sriov-network-operator
NAME     AGE
worker   126m

$ oc describe sriovnetworkpoolconfig -n openshift-sriov-network-operator worker
Name:         worker
Namespace:    openshift-sriov-network-operator
Labels:       <none>
Annotations:  <none>
API Version:  sriovnetwork.openshift.io/v1
Kind:         SriovNetworkPoolConfig
Metadata:
  Creation Timestamp:  2025-06-06T12:09:11Z
  Generation:          1
  Resource Version:    4320093
  UID:                 f1ff956a-ba6c-445e-88b4-d91a52991b6a
Spec:
  Max Unavailable:  1
  Node Selector:
    Match Labels:
      node-role.kubernetes.io/worker:  
  Rdma Mode:                           exclusive
Events:                                <none>

$ oc get sriovnetworknodestate -n openshift-sriov-network-operator -o json | grep rdma
                    "rdmaMode": "exclusive"
                    "rdmaMode": "exclusive"
                    "rdmaMode": "exclusive"
                    "rdmaMode": "exclusive"
                    "rdmaMode": "exclusive"
                    "rdmaMode": "exclusive"
```

- [x] Test with Intel cards - https://www.distributed-ci.io/jobs/c9012d79-9651-4511-84e0-0cd58f4aa751/jobStates

Automation with grout worked in a regular cluster. Changes were not affecting the default behavior. This is not using SriovNetworkPoolConfig.

Test-Hints: no-check