### PR TITLE
Include preflight workflow option

### DIFF
--- a/preflight/README.md
+++ b/preflight/README.md
@@ -15,3 +15,5 @@ The `preflight` directory contains several Ansible hooks involved in preparing a
     - We will take grout-operator-bundle for this test.
 - Build `preflight_containers_to_certify` variable based on the index content.
     - We will take trex-container images for this test.
+- Workflow selection with `example_cnf_preflight_workflow` variable:
+    - The `example_cnf_preflight_workflow` variable provides fine-grained control over which certification checks are executed. Its value can be set to `"all"`, `"operator"`, or `"container"`.

--- a/preflight/hooks/pre-run.yml
+++ b/preflight/hooks/pre-run.yml
@@ -22,7 +22,9 @@
   when: example_cnf_index_image is defined
 
 - name: Create the preflight_operators_to_certify variable
-  when: catalog_data_cmd.stdout_lines is defined
+  when:
+    - catalog_data_cmd.stdout_lines is defined
+    - example_cnf_preflight_workflow | default('all') in ['operator', 'all']
   block:
 
     - name: Create an empty preflight_operators_to_certify variable
@@ -40,7 +42,9 @@
         msg: "{{ preflight_operators_to_certify }}"
 
 - name: Create the preflight_containers_to_certify variable
-  when: catalog_data_cmd.stdout_lines is defined
+  when:
+    - catalog_data_cmd.stdout_lines is defined
+    - example_cnf_preflight_workflow | default('all') in ['container', 'all']
   block:
 
     - name: Create an empty preflight_containers_to_certify variable


### PR DESCRIPTION
By default, we'll test all preflight workflows, but let's add the chance to decide what workflow(s) can be tested (e.g. in preflight-green, we'll only test preflight container workflow on example-cnf images).